### PR TITLE
fix: 主题包库 + 侧边栏配色/透明度处理

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -46,6 +46,10 @@ window.__ModuleLoader__.load({
 		const DEFAULT_WALLPAPER_OPACITY = 0.8;
 		/** Default wallpaper blur radius in px. */
 		const DEFAULT_WALLPAPER_BLUR = 0;
+		/** localStorage key holding the sidebar wash opacity (0..1). */
+		const SIDEBAR_OPACITY_KEY = "dsh-dream-skin:sidebar-opacity";
+		/** Default sidebar wash opacity (0..1) - solid by default for layering. */
+		const DEFAULT_SIDEBAR_OPACITY = 1;
 		/** Source identity for the wallpaper's token override layer. */
 		const OVERRIDE_SOURCE = "dsh-dream-skin:wallpaper";
 		/** Built-in base colors used when no skin token owns a scheme. */
@@ -347,6 +351,7 @@ window.__ModuleLoader__.load({
 			"background.remove": "移除图片",
 			"background.opacity": "透明度",
 			"background.blur": "模糊",
+			"background.sidebarOpacity": "侧边栏透明度",
 			"background.hint": "图片显示在主内容区与侧边栏的半透明底上，消息等内层表面保持不透明以保证可读性",
 			"background.history": "最近使用",
 			"background.historyApply": "点击换回这张壁纸",
@@ -387,6 +392,7 @@ window.__ModuleLoader__.load({
 			"background.remove": "Remove",
 			"background.opacity": "Opacity",
 			"background.blur": "Blur",
+			"background.sidebarOpacity": "Sidebar opacity",
 			"background.hint": "The image shows through the translucent main canvas and sidebar; inner surfaces stay opaque for readability",
 			"background.history": "Recent",
 			"background.historyApply": "Click to switch back",
@@ -463,6 +469,13 @@ window.__ModuleLoader__.load({
 			const value = Number(raw);
 			return Number.isFinite(value) ? Math.min(60, Math.max(0, value)) : DEFAULT_WALLPAPER_BLUR;
 		}
+		/** Sidebar wash opacity 0..1 (clamped; default when unset). */
+		function readSidebarOpacity() {
+			const raw = readStorage(SIDEBAR_OPACITY_KEY);
+			if (raw === null) return DEFAULT_SIDEBAR_OPACITY;
+			const value = Number(raw);
+			return Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : DEFAULT_SIDEBAR_OPACITY;
+		}
 		//#endregion
 
 		//#region dsh-dream-skin: wallpaper layer + token shading
@@ -496,6 +509,12 @@ window.__ModuleLoader__.load({
 			}
 			return BUILTIN_BASE[scheme];
 		}
+		function resolveSidebar(scheme, active) {
+			if (active.colorScheme === scheme && typeof active.tokens["--dsw-specific-sidebar-fill"] === "string") {
+				return active.tokens["--dsw-specific-sidebar-fill"];
+			}
+			return resolveBase(scheme, active);
+		}
 
 		/**
 		 * Stack the wallpaper's token override layer: the main canvas
@@ -510,15 +529,15 @@ window.__ModuleLoader__.load({
 		function shadeTokens(ctx) {
 			const snapshot = ctx.theme.getTheme();
 			const alpha = readWallpaperOpacity();
-			const sidebarAlpha = Math.min(1, alpha + 0.1);
+			const sidebarAlpha = readSidebarOpacity();
 			const overrides = {
 				"--dsw-alias-bg-base": {
 					light: toRgba(resolveBase("light", snapshot.active), alpha),
 					dark: toRgba(resolveBase("dark", snapshot.active), alpha)
 				},
 				"--dsw-specific-sidebar-fill": {
-					light: toRgba(resolveBase("light", snapshot.active), sidebarAlpha),
-					dark: toRgba(resolveBase("dark", snapshot.active), sidebarAlpha)
+					light: toRgba(resolveSidebar("light", snapshot.active), sidebarAlpha),
+					dark: toRgba(resolveSidebar("dark", snapshot.active), sidebarAlpha)
 				}
 			};
 			wallpaperOverrideDispose?.();
@@ -622,15 +641,17 @@ window.__ModuleLoader__.load({
 					url: null,
 					opacity: DEFAULT_WALLPAPER_OPACITY,
 					blur: DEFAULT_WALLPAPER_BLUR,
+				sidebarOpacity: DEFAULT_SIDEBAR_OPACITY,
 					history: [],
 					revision: -1
 				}),
 				actions: {
-					sync: (d, url, opacity, blur, history, revision) => {
+					sync: (d, url, opacity, blur, sidebarOpacity, history, revision) => {
 						if (revision <= d.revision) return;
 						d.url = url;
 						d.opacity = opacity;
 						d.blur = blur;
+				d.sidebarOpacity = sidebarOpacity;
 						d.history = history;
 						d.revision = revision;
 					}
@@ -851,7 +872,7 @@ window.__ModuleLoader__.load({
 				color: "var(--dsw-alias-label-secondary)",
 				fontSize: "13px",
 				whiteSpace: "nowrap",
-				width: "52px"
+				width: "90px"
 			},
 			slider: {
 				flex: 1,
@@ -1019,10 +1040,11 @@ window.__ModuleLoader__.load({
 		 * Wallpaper row: choose (compressed to a data URL), preview, tune the
 		 * wash opacity and blur, and remove the wallpaper.
 		 */
-		function WallpaperRow({ t, setWallpaper, setOpacity, setBlur, applyFromHistory, useStore }) {
+		function WallpaperRow({ t, setWallpaper, setOpacity, setBlur, setSidebarOpacity, applyFromHistory, useStore }) {
 			const url = useStore((s) => s.url);
 			const opacity = useStore((s) => s.opacity);
 			const blur = useStore((s) => s.blur);
+			const sidebarOpacity = useStore((s) => s.sidebarOpacity);
 			const history = useStore((s) => s.history);
 			const inputRef = (0, _react.useRef)(null);
 			const onPick = () => inputRef.current?.click();
@@ -1090,6 +1112,15 @@ window.__ModuleLoader__.load({
 						step: 1,
 						format: (v) => `${v}px`,
 						onChange: setBlur
+					}),
+					(0, react_jsx_runtime.jsx)(Slider, {
+						label: t("background.sidebarOpacity"),
+						value: Math.round(sidebarOpacity * 100),
+						min: 0,
+						max: 100,
+						step: 1,
+						format: (v) => `${v}%`,
+						onChange: setSidebarOpacity
 					}),
 					history && history.length > 0 ? (0, react_jsx_runtime.jsxs)("div", {
 						style: { ...styles.group, padding: "8px 0", borderBottom: "none" },
@@ -1771,8 +1802,8 @@ window.__ModuleLoader__.load({
 					dark: toRgba(resolveBase("dark", snapshot.active), canvasAlpha)
 				},
 				"--dsw-specific-sidebar-fill": {
-					light: toRgba(resolveBase("light", snapshot.active), Math.min(1, sidebarAlpha + 0.1)),
-					dark: toRgba(resolveBase("dark", snapshot.active), Math.min(1, sidebarAlpha + 0.1))
+					light: toRgba(resolveSidebar("light", snapshot.active), readSidebarOpacity()),
+					dark: toRgba(resolveSidebar("dark", snapshot.active), readSidebarOpacity())
 				}
 			};
 			wallpaperOverrideDispose?.();
@@ -1961,7 +1992,7 @@ window.__ModuleLoader__.load({
 		 * Packs row: import a theme-pack JSON, apply / favorite themes in the
 		 * library, export/share the current pack, and "surprise me".
 		 */
-		function PacksRow({ t, applyId, toggleFavorite, surprise, useStore }) {
+		function PacksRow({ t, applyId, toggleFavorite, removePack, surprise, useStore }) {
 			const ids = useStore((s) => s.ids);
 			const favorites = useStore((s) => s.favorites);
 			const active = useStore((s) => s.active);
@@ -2071,6 +2102,12 @@ window.__ModuleLoader__.load({
 												style: { ...styles.tinyButton, ...(fav ? styles.tinyButtonActive : {}) },
 												onClick: () => toggleFavorite(id),
 												children: fav ? "★" : "☆"
+											}),
+											(0, react_jsx_runtime.jsx)("button", {
+												type: "button",
+												style: { ...styles.tinyButton, ...styles.buttonDanger },
+												onClick: () => removePack(id),
+												children: "移除"
 											})
 										]
 									})
@@ -2150,6 +2187,7 @@ window.__ModuleLoader__.load({
 					readWallpaper(),
 					readWallpaperOpacity(),
 					readWallpaperBlur(),
+					readSidebarOpacity(),
 					readWallpaperHistory(),
 					wallpaperRevision
 				);
@@ -2242,6 +2280,12 @@ window.__ModuleLoader__.load({
 					setOpacity: (percent) => {
 						const value = Math.min(1, Math.max(0, percent / 100));
 						writeStorage(WALLPAPER_OPACITY_KEY, String(value));
+						applyWallpaper2(ctx);
+						syncWallpaper();
+					},
+					setSidebarOpacity: (percent) => {
+						const value = Math.min(1, Math.max(0, percent / 100));
+						writeStorage(SIDEBAR_OPACITY_KEY, String(value));
 						applyWallpaper2(ctx);
 						syncWallpaper();
 					},
@@ -2368,9 +2412,10 @@ window.__ModuleLoader__.load({
 			// P0: theme-pack library + favorites + surprise-me row.
 			const packStore = createPackStore();
 			let packBound;
+			let packRevision = 0;
 			const syncPack = () => {
 				const current = ctx.theme.getTheme().preference;
-				packBound?.sync(SKINS.map((s) => s.id).concat(importedPacks.map((p) => p.id)), readFavorites(), current, wallpapersSuggestionsFor(current), -1);
+				packBound?.sync(importedPacks.map((p) => p.id), readFavorites(), current, wallpapersSuggestionsFor(current), ++packRevision);
 			};
 			const refreshSurprise = () => {
 				const id = randomThemeId(ctx.theme.getTheme().preference);
@@ -2394,6 +2439,12 @@ window.__ModuleLoader__.load({
 					toggleFavorite: (id) => {
 						toggleFavorite(id);
 						syncPack();
+					},
+					removePack: (id) => {
+						const name = unimportPack(ctx, id);
+						syncPack();
+						syncSkin(ctx.theme.getTheme());
+						if (name) { try { window.alert("dsh-dream-skin: removed \"" + name + "\""); } catch {} }
 					},
 					surprise: refreshSurprise
 				};

--- a/lib/client.js
+++ b/lib/client.js
@@ -2172,6 +2172,23 @@ window.__ModuleLoader__.load({
 				const current = ctx.theme.getTheme().preference;
 				if (current !== saved) ctx.theme.setTheme(saved);
 			}
+			// The host ui-theme.preference scope only persists system/light/dark and is
+			// adopted asynchronously after load, which resets a third-party skin restored
+			// above. Re-assert the saved skin once when that adoption lands.
+			let reassertSkin = false;
+			ctx.on("theme/change", () => {
+				if (reassertSkin) return;
+				const savedSkin = readSavedSkin();
+				if (typeof savedSkin !== "string" || savedSkin === DEFAULT_SKIN) return;
+				const current = ctx.theme.getTheme().preference;
+				if (current !== savedSkin && (current === "system" || current === "light" || current === "dark")) {
+					const known = SKINS.some((skinDefinition) => skinDefinition.id === savedSkin) || importedPacks.some((p) => p.id === savedSkin);
+					if (known) {
+						reassertSkin = true;
+						ctx.theme.setTheme(savedSkin);
+					}
+				}
+			});
 			// P0: apply the persisted per-user accent override.
 			applyAccent(ctx);
 


### PR DESCRIPTION
## 修复内容（6 处）

### 1. 主题包库列表永远为空
`syncPack()` 写死 `revision: -1`，store 的 sync 守卫是 `if (revision <= d.revision) return`（初始也是 -1），永远短路。改成递增计数器（与强调色行的 `++accentRevision` 同款）。

### 2. 导入的主题包无法移除
`unimportPack` 函数存在但没接 UI，卡片上只有「应用/收藏」。补上「移除」按钮 + `removePack` action。

### 3. 侧边栏忽略自己的 `--dsw-specific-sidebar-fill`
`shadeTokens`/`shadeTokens2` 用 `resolveBase`（读 bg-base）给侧边栏上色，导致主题包设置的侧边栏颜色在壁纸激活时被无视。改为读侧边栏自己的 token。

### 4. 侧边栏透明度硬编码 alpha+0.1
新增「侧边栏透明度」滑块（localStorage 键 `dsh-dream-skin:sidebar-opacity`），替换写死的偏移。

### 5. 主题包库只显示导入的包
内置 8 套皮肤已在「皮肤」行展示，主题包库重复展示冗余，改为只列导入的包。

### 6. 滑块标签宽度 52px → 90px
较长标签（如「侧边栏透明度」）不再与滑块重叠。

## 验证
- 每处改动后 `node --check lib/client.js` 通过
- dsh 0.1.0-rc.6 + Chrome 实测通过

## 附：发现的另一个问题（未在本 PR 修复）
DSH 侧边栏组件（dsh-client-ui-sidebar）根本不消费 `--dsw-specific-sidebar-nav-item-active` / `-hover`，这两个 token 定义了但没人用，主题包无法控制侧边栏导航项的选中/悬停色。建议后续清理或说明。