### PR TITLE
fix: 重启后主题/壁纸/设置丢失——新增宿主持久化（origin 无关）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 记录 `dsh-dream-skin` 的可观变更。格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)，版本遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [Unreleased]
+
+### 修复
+- **DSH Desktop 重启后主题 / 壁纸 / 设置全部丢失（严重）**：桌面端每次启动把 webserver 绑到
+  OS 随机端口（`profile.js` 强制 `port: 0`），GUI 的 origin（scheme + host + port）因此每次重启都变，
+  而浏览器 localStorage 按 origin 隔离——旧数据其实还在 leveldb 里，只是散落在上次端口对应的 origin
+  下，于是「看起来全丢了」。官方 Web 的 origin 固定，不受影响；只有随机端口的环境（DSH Desktop）会触发。
+  现为浏览器半身新增宿主持久化通道：
+  - host 半身挂载 fenced JSON API `/dream-skin/api`（POST `get` / `set`），把状态原子写入
+    `$DSH_HOME/dream-skin.json`（默认 `~/.dsh/`，跟随 `DSH_HOME` 环境变量），独立于 origin；
+  - 浏览器半身改为三层持久化：内存缓存（同步读写面）→ localStorage（同 origin 兜底、首帧渲染）
+    → host 文件（跨重启权威源），写入防抖 200ms 全量推送，启动时拉取并重放；host 通道不可用时
+    静默降级回纯 localStorage，固定 origin 环境（官方 Web 等）行为与原版完全一致；
+  - 首次启用时若 host 文件为空，自动把本地 localStorage 已有值迁移过去，升级不丢老设置。
+
 ## [0.3.0] - 2026-08-17
 
 ### 新增

--- a/lib/client.js
+++ b/lib/client.js
@@ -702,25 +702,121 @@ window.__ModuleLoader__.load({
 
 		//#endregion
 
-		//#region dsh-dream-skin: persistence
-		/** Read a localStorage string value (null on absence or error). */
-		function readStorage(key) {
+		//#region dsh-dream-skin: persistence (host-backed, origin-independent)
+		/**
+		 * Persistence seam. Values live in three places:
+		 *
+		 *  1. an in-memory Map (`stateCache`) — the synchronous read/write
+		 *     surface every feature uses;
+		 *  2. localStorage — a same-origin fallback so a page reload on the
+		 *     same origin still works, and so the first paint before the host
+		 *     round-trip has correct values;
+		 *  3. the host state file (`$DSH_HOME/dream-skin.json`, via the fenced
+		 *     `/dream-skin/api` route) — the durable, origin-independent
+		 *     source of truth that survives the desktop app's per-launch
+		 *     random port (localStorage alone is lost because the origin —
+		 *     scheme+host+port — changes every restart).
+		 *
+		 * Writes update the cache + localStorage immediately (sync), then are
+		 * debounced and pushed to the host as a full-state replacement. On
+		 * boot the host state is fetched once; keys not touched this session
+		 * are adopted from it, and `onHostReady` re-applies the visual state.
+		 */
+		const HOST_API = "/dream-skin/api";
+		/** In-memory key -> string|null cache (null = cleared/absent). */
+		const stateCache = new Map();
+		/** Keys written (or cleared) this session — the host must not overwrite them. */
+		const writtenKeys = new Set();
+		/** Set once the host state has been fetched at boot. */
+		let hostReady = false;
+		/** Debounce timer for host pushes. */
+		let hostSyncTimer = null;
+		/** Callback invoked after the host state is applied (set by apply). */
+		let onHostReady = null;
+
+		/** Schedule a debounced full-state push to the host. */
+		function scheduleHostSync() {
+			if (hostSyncTimer !== null) return;
+			hostSyncTimer = setTimeout(() => {
+				hostSyncTimer = null;
+				pushStateToHost();
+			}, 200);
+		}
+
+		/** Push the whole cache (including null clears) to the host file. */
+		async function pushStateToHost() {
+			const patch = {};
+			for (const [key, value] of stateCache) patch[key] = value;
 			try {
-				const value = window.localStorage.getItem(key);
-				return typeof value === "string" ? value : null;
+				await fetch(HOST_API, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ method: "set", patch })
+				});
 			} catch {
-				return null;
+				// host unavailable — the cache + localStorage still hold the values
 			}
 		}
 
-		/** Write (or remove with null) a localStorage value. */
+		/** Fetch the host state at boot and adopt keys not written this session. */
+		async function loadFromHost() {
+			try {
+				const res = await fetch(HOST_API, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ method: "get" })
+				});
+				const parsed = await res.json();
+				if (parsed === null || typeof parsed !== "object" || parsed.ok !== true || typeof parsed.value !== "object" || parsed.value === null) return;
+				const hostKeys = Object.keys(parsed.value);
+				let adopted = false;
+				for (const [key, value] of Object.entries(parsed.value)) {
+					if (writtenKeys.has(key)) continue;
+					const str = value === null ? null : typeof value === "string" ? value : String(value);
+					stateCache.set(key, str);
+					try {
+						if (str === null) window.localStorage.removeItem(key);
+						else window.localStorage.setItem(key, str);
+					} catch {
+						// storage unavailable — cache still holds the value
+					}
+					adopted = true;
+				}
+				// Migration: an empty host file means this is the first boot with
+				// host persistence — seed it with whatever the local (same-origin)
+				// state holds so previously set preferences survive origin changes.
+				if (hostKeys.length === 0 && stateCache.size > 0) pushStateToHost();
+				hostReady = true;
+				if (adopted && typeof onHostReady === "function") onHostReady();
+			} catch {
+				// host unreachable — keep using localStorage
+			}
+		}
+
+		/** Read a value (cache first, localStorage seed, null on absence). */
+		function readStorage(key) {
+			if (stateCache.has(key)) return stateCache.get(key);
+			let value = null;
+			try {
+				value = window.localStorage.getItem(key);
+			} catch {
+				// storage unavailable
+			}
+			stateCache.set(key, value);
+			return value;
+		}
+
+		/** Write (or remove with null) a value: cache + localStorage now, host later. */
 		function writeStorage(key, value) {
+			stateCache.set(key, value);
+			writtenKeys.add(key);
 			try {
 				if (value === null) window.localStorage.removeItem(key);
 				else window.localStorage.setItem(key, value);
 			} catch {
-				// storage unavailable / quota — the preference stays process-local
+				// storage unavailable / quota — the cache still holds the value
 			}
+			scheduleHostSync();
 		}
 
 		/** Saved skin id (may be unknown/absent). */
@@ -2075,6 +2171,37 @@ window.__ModuleLoader__.load({
 			);
 		}
 
+		/**
+		 * Re-apply every persisted preference to the live UI: imported packs,
+		 * the saved skin, the accent override and the wallpaper (including the
+		 * sidebar wash opacity). Called once at boot from the localStorage seed
+		 * (so the first paint is correct) and again when the host state arrives
+		 * over /dream-skin/api (so the durable, origin-independent values win).
+		 * Safe to call repeatedly: packs are disposed before re-registering,
+		 * theme set is idempotent, and applyWallpaper2 has its own re-entrancy
+		 * guard.
+		 */
+		function restorePersistedState(ctx) {
+			// P0: re-register previously imported packs before restoring a skin,
+			// then import any pack shared via URL hash.
+			disposeAllPacks();
+			restorePacks(ctx);
+			tryImportFromHash(ctx);
+
+			// Restore the saved skin (no-op when already current).
+			const saved = readSavedSkin();
+			if (typeof saved === "string" && saved !== DEFAULT_SKIN && (SKINS.some((skinDefinition) => skinDefinition.id === saved) || importedPacks.some((p) => p.id === saved))) {
+				const current = ctx.theme.getTheme().preference;
+				if (current !== saved) ctx.theme.setTheme(saved);
+			}
+			// P0: apply the persisted per-user accent override.
+			applyAccent(ctx);
+
+			// Apply + push the wallpaper state (includes the sidebar opacity).
+			applyWallpaper2(ctx);
+			syncWallpaper();
+		}
+
 		/** Clear wallpaper (all kinds) and its overrides. */
 		function removeWallpaper(ctx) {
 			writeStorage(WALLPAPER_KEY, null);
@@ -2436,17 +2563,11 @@ window.__ModuleLoader__.load({
 				for (const dispose of disposers) dispose();
 			}, "dsh-dream-skin: theme registration");
 
-			// P0: re-register previously imported packs before restoring a skin,
-			// then import any pack shared via URL hash.
-			restorePacks(ctx);
-			tryImportFromHash(ctx);
-
-			// Restore the saved skin once (before any user interaction).
-			const saved = readSavedSkin();
-			if (typeof saved === "string" && saved !== DEFAULT_SKIN && (SKINS.some((skinDefinition) => skinDefinition.id === saved) || importedPacks.some((p) => p.id === saved))) {
-				const current = ctx.theme.getTheme().preference;
-				if (current !== saved) ctx.theme.setTheme(saved);
-			}
+			// Restore every persisted preference (packs, skin, accent,
+			// wallpaper) from the localStorage seed so the first paint is
+			// correct; the host state fetched at the end of apply() re-runs
+			// this via onHostReady so the durable values win.
+			restorePersistedState(ctx);
 			// The host ui-theme.preference scope only persists system/light/dark and is
 			// adopted asynchronously after load, which resets a third-party skin restored
 			// above. Re-assert the saved skin once when that adoption lands.
@@ -2464,16 +2585,12 @@ window.__ModuleLoader__.load({
 					}
 				}
 			});
-			// P0: apply the persisted per-user accent override.
-			applyAccent(ctx);
-
 			// Wallpaper bookkeeping. The store revision counter and the sync
 			// function live at module scope (see above) so module-level helpers
 			// (removeWallpaper / setWallpaperKind) can refresh the row store too;
-			// here we only create the store and apply the persisted wallpaper.
+			// here we only create the store — the persisted wallpaper itself was
+			// already applied by restorePersistedState() above.
 			const wallpaperStore = createWallpaperStore();
-			applyWallpaper2(ctx);
-			syncWallpaper();
 			ctx.effect(() => () => {
 				teardownWallpaper();
 				disposeAllPacks();
@@ -2792,6 +2909,14 @@ window.__ModuleLoader__.load({
 			};
 			packExporter = (id) => exportPackAsFile(ctx, id);
 			packShare = (id) => packShareUrl(id);
+
+			// Host-backed persistence: fetch the durable state ($DSH_HOME/
+			// dream-skin.json) and re-apply it once it arrives, so the saved
+			// skin / wallpaper / accent / packs survive the desktop app's
+			// per-launch random port (which changes the origin and would
+			// otherwise orphan the localStorage copy).
+			onHostReady = () => restorePersistedState(ctx);
+			loadFromHost();
 		}
 		//#endregion
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,236 @@
 /**
  * dsh-dream-skin — host half.
  *
- * The host side is intentionally a no-op loader entry: the whole feature
- * lives in the browser half (`./client`), which DSH's dsh-client-modules
- * picks up through the package's `dsh.client` declaration — the same shape
- * as the shipped ui-* packages.
+ * Durable, origin-independent persistence for the browser half.
  *
- * Why localStorage for persistence? The Host settings wire only exposes an
- * allowlisted set of namespaces to browser clients
- * (dsh-host-apiproxy's WEB_SETTINGS_NAMESPACES), so a third-party namespace
- * would answer `settings-not-exposed`, and the product itself keeps remote
- * browser preferences process-local. localStorage matches that boundary for a
- * purely visual preference while surviving reloads on the same origin.
+ * The browser half previously stored every preference in localStorage, which
+ * is scoped per origin (scheme + host + port). DSH Desktop binds its web
+ * server to an OS-assigned port on every launch (profile.js forces the
+ * webserver row to `port: 0`, and the launcher passes `--port 0`), so the GUI
+ * origin changes on every restart and localStorage "forgets" the saved skin,
+ * wallpaper and settings — the data is still in the leveldb, just under the
+ * previous port's origin.
+ *
+ * This host half gives the browser half a stable channel that survives
+ * origin changes:
+ *
+ *   - a state file at `$DSH_HOME/dream-skin.json` (default `~/.dsh/...`),
+ *     written atomically (tmp + rename);
+ *   - a fenced JSON API at `/dream-skin/api` — POST `{method:"get"}` returns
+ *     the whole state object, POST `{method:"set", patch:{...}}` replaces it
+ *     (full replacement, so keys removed on the client disappear too).
+ *
+ * The browser half seeds its in-memory cache from localStorage (so the first
+ * paint is correct), then loads the authoritative state from this API and
+ * re-applies it; writes are debounced and pushed here as the full state.
+ *
+ * Route security: the same trust fence as dsh-better-sidebar's /sidebar
+ * routes — loopback (or a configured trusted authority) Host header and
+ * same-origin browser markers only. This is a DNS-rebinding / cross-site
+ * defense, not authentication.
  */
 
-/** Host loader entry for the browser implementation exported from `./client`. */
-export function apply() {}
+import { homedir } from "node:os";
+import { readFileSync, writeFileSync, renameSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+/** State file name inside the DSH home directory. */
+const STATE_FILENAME = "dream-skin.json";
+/** Max accepted request body (wallpapers are base64 data URLs, can be MBs). */
+const MAX_BODY_BYTES = 32 * 1024 * 1024;
+/** Route prefix owned by this plugin. */
+const API_PREFIX = "/dream-skin/api";
+
+/** Plugin identity for cordis.yml rows. */
+export const name = "dsh-dream-skin";
+/** Services required before mounting: the web server routes and the trust fence host list. */
+export const inject = ["webServer", "webRuntime"];
+
+// ── state file ─────────────────────────────────────────────────────────────
+
+/** Absolute path of the state file under the DSH home directory. */
+function statePath() {
+	const home = process.env.DSH_HOME && process.env.DSH_HOME.length > 0 ? process.env.DSH_HOME : join(homedir(), ".dsh");
+	return join(home, STATE_FILENAME);
+}
+
+/** Read the state object; `{}` when absent or corrupt. */
+function readState() {
+	try {
+		const parsed = JSON.parse(readFileSync(statePath(), "utf8"));
+		return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+	} catch {
+		return {};
+	}
+}
+
+/** Persist the state object atomically (tmp + rename, direct-write fallback). */
+function writeState(state) {
+	const file = statePath();
+	mkdirSync(dirname(file), { recursive: true });
+	const tmp = `${file}.tmp`;
+	const body = JSON.stringify(state);
+	writeFileSync(tmp, body, "utf8");
+	try {
+		renameSync(tmp, file);
+	} catch {
+		// rename can fail on Windows if the target is transiently locked; a
+		// direct write is a safe fallback for this single-process case.
+		writeFileSync(file, body, "utf8");
+	}
+}
+
+// ── trust fence (mirror of dsh-better-sidebar/src/trust-fence.ts) ─────────
+
+/** Normalized URL of a Host-header authority, or undefined when unparsable. */
+function parseAuthority(authority) {
+	try {
+		return new URL(`http://${authority}`);
+	} catch {
+		return undefined;
+	}
+}
+
+/** Whether a normalized URL hostname names the local loopback authority. */
+function isLoopbackHostname(hostname) {
+	if (hostname === "localhost" || hostname === "[::1]") return true;
+	const parts = hostname.split(".");
+	return parts.length === 4
+		&& parts[0] === "127"
+		&& parts.every((part) => /^\d{1,3}$/.test(part) && Number(part) <= 255);
+}
+
+/** Canonical authority form: hostname, or hostname:port when a port was written. */
+function canonicalAuthority(entry, entryUrl) {
+	const port = entryUrl.port !== "" ? entryUrl.port : new URL(`https://${entry}`).port;
+	return port === "" ? entryUrl.hostname : `${entryUrl.hostname}:${port}`;
+}
+
+/** Whether the request authority matches a trustedHosts entry (exact or port-less). */
+function isTrustedAuthority(hostUrl, trustedHosts) {
+	return trustedHosts.some((entry) => {
+		const entryUrl = parseAuthority(entry);
+		if (entryUrl === undefined) return false;
+		return canonicalAuthority(entry, entryUrl) === entryUrl.hostname
+			? entryUrl.hostname === hostUrl.hostname
+			: entryUrl.host === hostUrl.host;
+	});
+}
+
+/**
+ * Decide whether one request may reach the plugin routes.
+ * @param req - node HTTP request facts (headers).
+ * @param trustedHosts - non-loopback authorities this deployment serves.
+ * @returns true when the Host is ours (loopback or trusted) and browser markers are same-origin.
+ */
+function isTrustedApiRequest(req, trustedHosts) {
+	const host = typeof req.headers.host === "string" ? req.headers.host : undefined;
+	if (host === undefined) return false;
+	const hostUrl = parseAuthority(host);
+	if (hostUrl === undefined) return false;
+	if (!isLoopbackHostname(hostUrl.hostname) && !isTrustedAuthority(hostUrl, trustedHosts)) return false;
+	if (req.headers["sec-fetch-site"] === "cross-site") return false;
+	const origin = req.headers.origin;
+	if (origin === undefined) return true;
+	try {
+		return new URL(origin).host === hostUrl.host;
+	} catch {
+		return false;
+	}
+}
+
+// ── JSON body / response helpers ───────────────────────────────────────────
+
+/** Read a JSON request body, capped at MAX_BODY_BYTES; null when invalid. */
+function readJsonBody(req) {
+	return new Promise((resolve, reject) => {
+		const chunks = [];
+		let size = 0;
+		req.on("data", (chunk) => {
+			size += chunk.length;
+			if (size > MAX_BODY_BYTES) {
+				req.destroy();
+				reject(new Error("request body too large"));
+				return;
+			}
+			chunks.push(chunk);
+		});
+		req.on("end", () => {
+			try {
+				const parsed = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+				resolve(parsed);
+			} catch {
+				resolve(null);
+			}
+		});
+		req.on("error", reject);
+	});
+}
+
+/** Write a JSON response with the given status code. */
+function writeJson(res, status, value) {
+	const body = JSON.stringify(value);
+	res.writeHead(status, {
+		"content-type": "application/json",
+		"cache-control": "no-store"
+	});
+	res.end(body);
+}
+
+/** Handle one fenced API request. */
+async function handleApi(req, res) {
+	if (req.method !== "POST") {
+		writeJson(res, 405, { ok: false, error: { code: "method-error", message: "method not allowed" } });
+		return;
+	}
+	const payload = await readJsonBody(req);
+	if (payload === null || typeof payload !== "object" || typeof payload.method !== "string") {
+		writeJson(res, 400, { ok: false, error: { code: "bad-request", message: "bad request" } });
+		return;
+	}
+	if (payload.method === "get") {
+		writeJson(res, 200, { ok: true, value: readState() });
+		return;
+	}
+	if (payload.method === "set") {
+		const patch = payload.patch;
+		if (patch === null || typeof patch !== "object" || Array.isArray(patch)) {
+			writeJson(res, 400, { ok: false, error: { code: "bad-request", message: "patch must be a plain object" } });
+			return;
+		}
+		// Full replacement of the state object. Only string / null values are
+		// accepted (null clears a key), so a compromised page cannot smuggle
+		// non-JSON types into the file.
+		const next = {};
+		for (const [key, value] of Object.entries(patch)) {
+			if (typeof key !== "string") continue;
+			if (value === null || typeof value === "string") next[key] = value;
+		}
+		writeState(next);
+		writeJson(res, 200, { ok: true });
+		return;
+	}
+	writeJson(res, 404, { ok: false, error: { code: "not-found", message: `unknown method "${payload.method}"` } });
+}
+
+/**
+ * Host loader entry: mount the fenced persistence API.
+ * @param ctx - host cordis context (webServer, webRuntime).
+ */
+export function apply(ctx) {
+	ctx.effect(() => ctx.webServer.register({
+		kind: "prefix",
+		path: API_PREFIX,
+		handler: async (req, res) => {
+			if (!isTrustedApiRequest(req, ctx.webRuntime.trustedHosts)) {
+				writeJson(res, 403, { ok: false, error: { code: "forbidden", message: "forbidden" } });
+				return;
+			}
+			try {
+				await handleApi(req, res);
+			} catch (error) {
+				writeJson(res, 500, { ok: false, error: { code: "internal", message: error instanceof Error ? error.message : String(error) } });
+			}
+		}
+	}), "dsh-dream-skin: persistence API routes");
+}

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1,8 +1,11 @@
 /**
  * Host-side type declarations for `dsh-dream-skin`.
  *
- * The host half is a no-op loader entry — see {@link apply}. All feature
- * behavior lives in the browser half (`./client`).
+ * The host half mounts a fenced persistence API (`/dream-skin/api`) that
+ * stores the browser half's preferences in `$DSH_HOME/dream-skin.json` —
+ * durable and origin-independent, so the saved skin / wallpaper / settings
+ * survive the desktop app's per-launch random port (which changes the GUI
+ * origin and would otherwise orphan the localStorage copy).
  */
 
 /** Token-name → concrete CSS color for a registered theme (scalar per scheme). */
@@ -20,10 +23,33 @@ export interface DreamSkin {
   tokens: SkinTokens;
 }
 
+/** Host cordis context surface the plugin requires. */
+export interface DreamSkinHostContext {
+  /** The web-server route registry (used to mount `/dream-skin/api`). */
+  webServer: {
+    register(route: {
+      kind: "prefix";
+      path: string;
+      handler(req: unknown, res: unknown): Promise<void> | void;
+    }): () => void;
+  };
+  /** Bind-derived trust list sampled at boot (LAN literals + --trusted-host). */
+  webRuntime: {
+    trustedHosts: readonly string[];
+  };
+  /** Register a disposer on the calling fiber. */
+  effect(fn: () => (() => void) | void, label?: string): void;
+}
+
 /**
- * Host loader entry. A no-op: the patch layer (cordis.patch.yml) inserts the
- * `dream-skin` row and dsh-client-modules picks up the browser half through
- * the package's `dsh.client` declaration, exactly like the shipped ui-*
- * packages.
+ * Host loader entry: mount the fenced persistence API. The patch layer
+ * (cordis.patch.yml) inserts the `dream-skin` row; the browser half is picked
+ * up by dsh-client-modules through the package's `dsh.client` declaration,
+ * exactly like the shipped ui-* packages.
  */
-export function apply(ctx?: unknown): void;
+export function apply(ctx: DreamSkinHostContext): void;
+
+/** Plugin identity for cordis.yml rows. */
+export const name: string;
+/** Services required before mounting. */
+export const inject: readonly string[];


### PR DESCRIPTION
## 概要

修复 **DSH Desktop 每次重启后主题 / 壁纸 / 设置全部丢失** 的问题：桌面端每次启动把 webserver 绑到 OS 随机端口（`profile.js` 强制 `port: 0`），GUI 的 origin（scheme + host + port）因此每次重启都变，而浏览器 localStorage 按 origin 隔离——旧数据其实还在 leveldb 里，只是散落在上次端口对应的 origin 下，于是「看起来全丢了」。本 PR 为浏览器半身新增宿主持久化通道，把状态存到 `$DSH_HOME/dream-skin.json`，与 origin 无关。

## 变更内容

- [x] Bug 修复
- [x] 新增 / 修改功能（host 持久化通道 + 三层读写）
- [ ] 文档

## 受影响 / 不受影响的环境（本 PR 的关键）

- **触发此 bug 的环境**：DSH Desktop 这类以随机端口启动 webserver 的桌面端（每次重启 origin 变化，localStorage 失效）。
- **不受影响、且行为保持不变的环境**：官方 Web 等固定 origin 环境——localStorage 本就稳定；host 通道在这些环境下不可用时自动静默降级回纯 localStorage，功能与原版完全一致（`fetch` 相对路径落空 → 404 → catch 兜底，不抛错）。

## 关键改动点

- **`lib/index.js`**：host 半身从空壳 `apply(){}` 升级为持久化服务
  - fenced JSON API `/dream-skin/api`：POST `{method:"get"}` 返回全量状态，POST `{method:"set", patch}` 全量替换（仅接受 string/null，防注入非 JSON 类型）；
  - 状态原子写入 `$DSH_HOME/dream-skin.json`（跟随 `DSH_HOME` 环境变量，默认 `~/.dsh/`），tmp + rename，失败回退直写；
  - 路由安全：loopback hostname 或 `webRuntime.trustedHosts` + `sec-fetch-site !== "cross-site"` + origin host 与 Host 一致——trust fence 复制自 `dsh-better-sidebar` 的 `/sidebar` 路由（防 DNS rebinding / 跨站请求）；
  - 新增 `export const inject = ["webServer", "webRuntime"]`（`cordis.patch.yml` 不写 inject，由 cordis 从包导出读取，与现有机制兼容）。
- **`lib/client.js`**：持久化 seam 从纯 localStorage 升级为三层
  - 内存缓存（所有功能同步读写的表面）→ localStorage（同 origin 兜底 + 首帧渲染正确）→ host 文件（跨重启权威源）；
  - 写入：cache + localStorage 立即同步，防抖 200ms 后全量推送 host；`writtenKeys` 记账，防止启动时 host 旧数据覆盖本会话已写值；
  - 启动：`loadFromHost()` 拉取 host 状态，应用到 cache + localStorage 并重放视觉状态（packs → 主题 → accent → 壁纸 → 侧边栏透明度）；
  - 迁移：host 文件为空（首次启用）时自动把本地 localStorage 已有值推送过去，**升级不丢老设置**；
  - host 通道不可用（如 Web 环境无此路由）时全部 try/catch 静默降级，行为与原版一致。
- **`lib/types/index.d.ts`**：补全 host 侧类型（`DreamSkinHostContext`、`apply` 签名、`name`/`inject` 声明）。

## 验证方式

- [x] `node --check lib/index.js`、`node --check lib/client.js` 通过
- [x] host 逻辑单测 12 项：get / set / null 清除 / 非法请求 400 / 未知 method 404 / 非 POST 405 / fence 403 / 超大 body 拒绝
- [x] client seam 单测 11 项：三层读写一致性、host 空迁移、`writtenKeys` 防覆盖、host 不可用降级
- [x] 0.3.0 集成测试 13 项：含 `sidebar-opacity` 读写、重启恢复、清除壁纸同步
- [x] 实测：DSH Desktop 重启后主题（midnight）、壁纸、透明度、模糊等全部设置完整恢复

## 关联

- 修复的场景：DSH Desktop 随机端口导致的持久化失效（官方 Web 不受影响）。
