### PR TITLE
fix: keep saved third-party skin across repeated host adoption

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2441,29 +2441,42 @@ window.__ModuleLoader__.load({
 			restorePacks(ctx);
 			tryImportFromHash(ctx);
 
-			// Restore the saved skin once (before any user interaction).
-			const saved = readSavedSkin();
-			if (typeof saved === "string" && saved !== DEFAULT_SKIN && (SKINS.some((skinDefinition) => skinDefinition.id === saved) || importedPacks.some((p) => p.id === saved))) {
-				const current = ctx.theme.getTheme().preference;
-				if (current !== saved) ctx.theme.setTheme(saved);
-			}
-			// The host ui-theme.preference scope only persists system/light/dark and is
-			// adopted asynchronously after load, which resets a third-party skin restored
-			// above. Re-assert the saved skin once when that adoption lands.
-			let reassertSkin = false;
-			ctx.on("theme/change", () => {
-				if (reassertSkin) return;
+			// Custom skin ids live in browser localStorage while ThemeRuntime persists
+			// only system/light/dark. Keep one restore path so an asynchronous host
+			// adoption cannot overwrite a saved third-party skin after page boot.
+			const restoreSavedSkin = () => {
 				const savedSkin = readSavedSkin();
-				if (typeof savedSkin !== "string" || savedSkin === DEFAULT_SKIN) return;
-				const current = ctx.theme.getTheme().preference;
-				if (current !== savedSkin && (current === "system" || current === "light" || current === "dark")) {
-					const known = SKINS.some((skinDefinition) => skinDefinition.id === savedSkin) || importedPacks.some((p) => p.id === savedSkin);
-					if (known) {
-						reassertSkin = true;
-						ctx.theme.setTheme(savedSkin);
-					}
+				if (typeof savedSkin !== "string" || savedSkin === DEFAULT_SKIN) return false;
+				const known = SKINS.some((skinDefinition) => skinDefinition.id === savedSkin) || importedPacks.some((p) => p.id === savedSkin);
+				if (!known || ctx.theme.getTheme().preference === savedSkin) return known;
+				try {
+					ctx.theme.setTheme(savedSkin);
+					return true;
+				} catch {
+					return false;
 				}
+			};
+			let restoreTimer = null;
+			const scheduleSkinRestore = () => {
+				if (restoreTimer !== null) clearTimeout(restoreTimer);
+				restoreTimer = setTimeout(() => {
+					restoreTimer = null;
+					restoreSavedSkin();
+				}, 0);
+			};
+			restoreSavedSkin();
+			// Covers both an adoption that arrives after the first restore and later
+			// connection/settings re-adoptions. A deliberate Default selection clears
+			// the saved id before this deferred callback can restore anything.
+			ctx.on("theme/change", (snapshot) => {
+				const savedSkin = readSavedSkin();
+				const builtIn = snapshot.preference === "system" || snapshot.preference === "light" || snapshot.preference === "dark";
+				if (typeof savedSkin === "string" && savedSkin !== DEFAULT_SKIN && builtIn) scheduleSkinRestore();
 			});
+			scheduleSkinRestore();
+			ctx.effect(() => () => {
+				if (restoreTimer !== null) clearTimeout(restoreTimer);
+			}, "dsh-dream-skin: sticky skin restore");
 			// P0: apply the persisted per-user accent override.
 			applyAccent(ctx);
 

--- a/tests/client.smoke.test.cjs
+++ b/tests/client.smoke.test.cjs
@@ -315,6 +315,62 @@ test('setWallpaper resets kind to image so a picked photo beats a stale gradient
 	assert.equal(h.localStorage.getItem('dsh-dream-skin:wallpaper'), 'data:image/jpeg;base64,AAAA');
 });
 
+test('saved third-party skin survives repeated delayed host adoption (sticky restore)', async () => {
+	// Regression: ThemeRuntime only persists system/light/dark to the host settings
+	// scope, so an asynchronous host adoption (connection reset / settings reload)
+	// resets a saved third-party skin like "midnight" to "system". The upstream
+	// once-only reassert could not cover adoptions arriving after it, or repeated
+	// re-adoptions. The sticky restore must re-apply the saved skin on every
+	// fallback to a built-in preference, but never after the user clears it.
+	const h = buildSandbox({ seed: { 'dsh-dream-skin:skin': 'midnight' } });
+	const e = h.factory(makeRequire(makeRuntime().RT));
+
+	const handlers = [];
+	let pref = 'system';
+	const setCalls = [];
+	const theme = {
+		register() { return () => {}; },
+		setTheme(id) { pref = id; setCalls.push(id); },
+		getTheme() { return { preference: pref, active: { id: 'dark', colorScheme: 'dark', tokens: {} }, themes: [], revision: 1 }; },
+		overrideTokens() { return () => {}; }
+	};
+	const ctx = {
+		theme,
+		slots: { inject() {}, register() { return {}; } },
+		locale: { register() {}, bind() { return (key) => key; } },
+		on(ev, fn) { if (ev === 'theme/change') handlers.push(fn); return () => {}; },
+		effect(t) { const d = t(); if (typeof d === 'function') d(); }
+	};
+	// Emit a theme/change as the ThemeRuntime does after adopting the host scope.
+	const emit = (preference) => {
+		pref = preference;
+		for (const fn of handlers) fn({ preference, active: { id: 'dark', colorScheme: 'dark', tokens: {} }, revision: 2 });
+	};
+	const tick = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+	assert.doesNotThrow(() => e.apply(ctx));
+	await tick();
+	const midnightCalls = () => setCalls.filter((id) => id === 'midnight').length;
+	assert.ok(midnightCalls() >= 1, 'saved midnight skin restored at boot');
+	const bootCount = midnightCalls();
+
+	// First delayed host adoption falls back to "system" — the saved skin must be re-applied.
+	emit('system');
+	await tick();
+	assert.equal(midnightCalls(), bootCount + 1, 'skin re-applied after the first adoption');
+
+	// A second re-adoption must be corrected too (the once-only reassert regressed here).
+	emit('system');
+	await tick();
+	assert.equal(midnightCalls(), bootCount + 2, 'skin re-applied after a repeated adoption');
+
+	// A deliberate Default selection clears the saved id; nothing may be restored.
+	h.localStorage.removeItem('dsh-dream-skin:skin');
+	emit('system');
+	await tick();
+	assert.equal(midnightCalls(), bootCount + 2, 'no restore after the user cleared the skin');
+});
+
 test('all locale dictionaries are complete and keep placeholders', () => {
 	// Every shipped dictionary must have exactly the zh key set (no missing /
 	// extra keys) and must keep the {name} / {error} / {errors} placeholders.


### PR DESCRIPTION
# PR：让已保存的第三方皮肤在多次宿主重采纳后仍保持（sticky skin restore）

> 仓库：github.com/RevolutionLA/dsh-dream-skin
> 分支：`fix/persist-skin-after-repeated-adoption`（commit `d570b6f`）
> 提交文件：`lib/client.js`、`tests/client.smoke.test.cjs`（+89 / -20）

## 问题（Problem）

用户选择第三方皮肤（如 `midnight`）后，**刷新页面或宿主设置重新采纳时，主题会自动回退为默认（system）**。

根因：

- `ThemeRuntime`（`@deepseek-ai/dsh-client-ui-theme`）只把内置偏好 `system / light / dark`
  持久化到宿主 `ui-theme` 设置作用域（`isThemePreference()` 只认这三个值）。
- 第三方皮肤 id（`midnight` 等）只保存在浏览器 `localStorage`（`dsh-dream-skin:skin`）。
- 宿主设置作用域在页面启动、连接重置、设置重载时会**异步重新采纳**（`ThemeRuntime.adopt()`），
  读回 `system` 并发布 `theme/change`，把内存中已恢复的第三方皮肤覆盖掉。
- 旧实现（0.3.0 的一次性 `reassertSkin`）只重断言一次；若最后一次回退发生在它之后，
  或发生多次重采纳，皮肤仍会丢失。

## 修复（Fix）

把一次性重断言改为**持续但有条件**的恢复：

1. `restoreSavedSkin()`：统一读取 `localStorage`，确认皮肤仍已注册后再应用；
2. 启动时立即恢复一次，并在下一个 tick 再校正一次，覆盖异步 host adoption；
3. 监听 `theme/change`：仅当当前偏好回退到内置值（`system/light/dark`）时延迟恢复，
   因此不会与用户主动切换皮肤冲突；
4. 用户主动选「默认（Default）」会清除保存的 id，恢复逻辑随之失效；
5. 插件卸载时清理恢复定时器。

## 回归测试（Test）

新增 `saved third-party skin survives repeated delayed host adoption (sticky restore)`：

- 预置 `dsh-dream-skin:skin = "midnight"`；
- 应用后模拟宿主**两次**延迟重采纳（`theme/change → system`）；
- 断言每次回退后 `setTheme("midnight")` 都被重新调用；
- 用户清除皮肤后再次回退，断言不再恢复。

测试通过：`npm test` → 10/10 pass。

## 验证（Manual verification）

在 DSH web profile 中安装本分支（`dsh plugin --profile web add -w <repo>` 或 npm 本地包），
选择 midnight 后多次刷新 / 触发连接重置，主题保持 midnight 不回退。

## 影响范围（Impact）

仅 `lib/client.js` 的皮肤恢复逻辑 + 测试文件；不涉及词典、UI、样式。
