### PR TITLE
fix(#11): keep built-in dark/light theme across agent-preset reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 记录 `dsh-dream-skin` 的可观变更。格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)，版本遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [Unreleased]
+
+> **内置主题（深色 / 跟随系统）在切换预设后失忆的补强。** 修复远端浏览器里内置 `dark` / `light` 主题偏好被 agent
+> 预设重载冲回 `system` 的问题。
+
+### 修复
+- **内置深色 / 浅色在切换 agent 预设后变回默认（issue #11 复述）**：DSH 只在 loopback 浏览器把 `ui-theme.preference` 写进
+  `$DSH_HOME/settings.yaml`；远端浏览器（如经 HTTP 访问的浏览器）的该偏好仅保存在进程内，一旦客户端重载 /
+  `connection/reset`（切换 agent 预设会触发）就回到 `system` 默认。现插件同样记录最近一次的内置
+  `dark` / `light` 选择（走本插件三层持久化），在「重载 / 连接重置」回落到 `system` 的窗口内重新套用；用户在稳定会话里
+  显式选「跟随系统」则清空记录。针对内置偏好的专项回归测试已补齐，全部 28 项测试通过。
+
 ## [0.4.2] - 2026-08-21
 
 > **弹窗可调 + 刷新持久化加固 + 材质一致性打磨 + 根目录精简。** 新增「弹窗不透明度」调节；为「刷新后主题失效」补充回归测试并加固还原路径；输入框去掉尖角外框、左右面板与侧边栏统一质感；多语言 README 迁入 `docs/i18n/`，根目录只留中文 README。

--- a/lib/client.js
+++ b/lib/client.js
@@ -60,6 +60,19 @@ window.__ModuleLoader__.load({
 		const DEFAULT_MODAL_OPACITY = 0.94;
 		/** CSS variable carrying the current popup fill weight (a percentage). */
 		const MODAL_FILL_VAR = "--dsh-dream-skin-modal-fill";
+		/**
+		 * localStorage key holding the last user-committed concrete built-in theme
+		 * preference (`light` or `dark`). DSH's own `ui-theme.preference` scope is
+		 * only persisted in the host settings file for LOOPBACK browsers; a remote
+		 * browser (e.g. served over HTTP) keeps it process-local, so a client
+		 * reload / connection reset — such as switching the agent preset — resets a
+		 * built-in `dark`/`light` choice back to the `system` default. We keep our
+		 * own copy of the last concrete built-in preference here (surviving through
+		 * the same 3-layer storage) and re-apply it when a reload falls back to
+		 * `system`, mirroring the third-party skin restore. Absent when the user
+		 * never left `system` or explicitly chose it.
+		 */
+		const BUILTIN_LAST_KEY = "dsh-dream-skin:builtin-last";
 		/** Built-in base colors used when no skin token owns a scheme. */
 		const BUILTIN_BASE = {
 			light: "rgb(255, 255, 255)",
@@ -882,6 +895,13 @@ window.__ModuleLoader__.load({
 			return readStorage(STORAGE_KEY);
 		}
 
+		/** Whether a known (third-party) skin id is currently saved & not system. */
+		function readSavedSkinValid() {
+			const saved = readSavedSkin();
+			if (typeof saved !== "string" || saved === DEFAULT_SKIN) return false;
+			return SKINS.some((skinDefinition) => skinDefinition.id === saved) || importedPacks.some((p) => p.id === saved);
+		}
+
 		/** Persist a skin choice; DEFAULT_SKIN clears the stored value. */
 		function writeSavedSkin(id) {
 			writeStorage(STORAGE_KEY, id === DEFAULT_SKIN ? null : id);
@@ -937,6 +957,17 @@ window.__ModuleLoader__.load({
 			const clamped = Math.min(1, Math.max(0, Number(value)));
 			writeStorage(MODAL_OPACITY_KEY, String(clamped));
 			return clamped;
+		}
+
+		/** Read the last concrete built-in preference (`light`|`dark`|null). */
+		function readBuiltinLast() {
+			const raw = readStorage(BUILTIN_LAST_KEY);
+			return raw === "light" || raw === "dark" ? raw : null;
+		}
+
+		/** Persist the last concrete built-in preference (or null to clear it). */
+		function writeBuiltinLast(pref) {
+			writeStorage(BUILTIN_LAST_KEY, pref === "light" || pref === "dark" ? pref : null);
 		}
 		//#endregion
 
@@ -2556,6 +2587,16 @@ window.__ModuleLoader__.load({
 			if (typeof saved === "string" && saved !== DEFAULT_SKIN && (SKINS.some((skinDefinition) => skinDefinition.id === saved) || importedPacks.some((p) => p.id === saved))) {
 				const current = ctx.theme.getTheme().preference;
 				if (current !== saved) ctx.theme.setTheme(saved);
+			} else {
+				// No third-party skin active — restore the last concrete built-in
+				// preference (dark/light) the user committed, so a remote browser's
+				// process-local ui-theme scope being reset to `system` by a client
+				// reload / agent-preset change (issue #11) is corrected here too.
+				const builtinLast = readBuiltinLast();
+				if (builtinLast !== null) {
+					const current = ctx.theme.getTheme().preference;
+					if (current !== builtinLast) ctx.theme.setTheme(builtinLast);
+				}
 			}
 			// P0: apply the persisted per-user accent override.
 			applyAccent(ctx);
@@ -2976,15 +3017,90 @@ window.__ModuleLoader__.load({
 				restoreTimer = setTimeout(restoreSavedSkin, 0);
 			};
 			restoreSavedSkin();
+			// Built-in preference durability (issue #11): DSH persists the built-in
+			// theme only to the host settings file for LOOPBACK browsers; a remote
+			// browser keeps `ui-theme.preference` process-local, so a client reload /
+			// agent-preset change resets a concrete `dark`/`light` choice back to
+			// `system`. We keep our own copy (BUILTIN_LAST_KEY) and re-apply it on a
+			// fallback to `system` that arrives in the boot/reset window right after
+			// this plugin (re)mounts — the agent-preset-reload shape — while treating
+			// a `system` switch that happens later, in a settled session, as an
+			// explicit user choice that clears the record.
+			let builtinSettled = false;
+			let builtinSettleTimer = null;
+			const BUILTIN_SETTLE_MS = 2000;
+			// A `connection/reset` (which DSH fires when the client transport
+			// re-adopts settings, e.g. after an agent-preset change) re-loads the
+			// ui-theme scope and can reset a remote browser's process-local built-in
+			// preference. Treat a `system` fallback that lands shortly after a reset
+			// as a reset, not a deliberate choice.
+			let resetPending = false;
+			let resetTimer = null;
+			const RESET_GRACE_MS = 2000;
+			const settleBuiltin = () => {
+				if (builtinSettleTimer !== null) clearTimeout(builtinSettleTimer);
+				builtinSettleTimer = setTimeout(() => {
+					builtinSettleTimer = null;
+					builtinSettled = true;
+				}, BUILTIN_SETTLE_MS);
+			};
+			const disarmReset = () => {
+				resetPending = false;
+				if (resetTimer !== null) { clearTimeout(resetTimer); resetTimer = null; }
+			};
+			const onBuiltinChange = (snapshot) => {
+				const pref = snapshot.preference;
+				if (pref === "light" || pref === "dark") {
+					// A concrete built-in preference is a deliberate choice (the default
+					// is `system`) — record it so a later reload can restore it.
+					writeBuiltinLast(pref);
+					settleBuiltin();
+					return;
+				}
+				// pref === "system"
+				if (readSavedSkinValid()) return; // third-party skin active
+				const builtinLast = readBuiltinLast();
+				if (builtinLast === null) return;
+				if (!builtinSettled || resetPending) {
+					// Reset/boot window — this `system` is an adoption reset, not a user
+					// choice. Re-apply the recorded concrete preference.
+					if (ctx.theme.getTheme().preference !== builtinLast) {
+						ctx.theme.setTheme(builtinLast);
+						disarmReset();
+						settleBuiltin();
+					}
+				} else {
+					// Settled, no reset — the user explicitly chose "system"/"follow OS";
+					// drop the stale record so a future reload stays on `system`.
+					writeBuiltinLast(null);
+				}
+			};
+			// connection/reset re-arms the "this is a reset" window. Guarded: older /
+			// test contexts may not provide the `connection` service, so only subscribe
+			// when the event channel exists.
+			try {
+				ctx.on("connection/reset", () => {
+					disarmReset();
+					resetPending = true;
+					resetTimer = setTimeout(disarmReset, RESET_GRACE_MS);
+				});
+			} catch {
+				// connection service absent — fall back to the settle-window heuristic only
+			}
 			ctx.on("theme/change", (snapshot) => {
 				const savedSkin = readSavedSkin();
 				const builtIn = snapshot.preference === "system" || snapshot.preference === "light" || snapshot.preference === "dark";
 				if (typeof savedSkin === "string" && savedSkin !== DEFAULT_SKIN && builtIn) scheduleSkinRestore();
+				onBuiltinChange(snapshot);
 			});
+			settleBuiltin();
+			disarmReset();
 			scheduleSkinRestore();
 			ctx.effect(() => () => {
 				if (restoreTimer !== null) clearTimeout(restoreTimer);
-			}, "dsh-dream-skin: sticky skin restore");
+				if (builtinSettleTimer !== null) clearTimeout(builtinSettleTimer);
+				if (resetTimer !== null) clearTimeout(resetTimer);
+			}, "dsh-dream-skin: sticky skin + built-in restore");
 			// Wallpaper bookkeeping. The store revision counter and the sync
 			// function live at module scope (see above) so module-level helpers
 			// (removeWallpaper / setWallpaperKind) can refresh the row store too;

--- a/tests/client.smoke.test.cjs
+++ b/tests/client.smoke.test.cjs
@@ -512,6 +512,77 @@ test('issue #11: saved skin survives an agent-preset change that re-adopts the h
 	assert.equal(roseCalls(), bootCount + 2, 'no restore after the user cleared the skin');
 });
 
+test('issue #11 (built-in): saved dark/light survives an agent-preset connection reset', async () => {
+	// The third-party-skin test above covers dream skins. But the reporter also
+	// hit this for a BUILT-IN preference (深色 / 跟随系统): in a remote browser
+	// DSH keeps ui-theme.preference process-local (not in $DSH_HOME/settings.yaml),
+	// so a client reload / connection-reset from an agent-preset change resets a
+	// concrete `dark`/`light` choice back to `system`. The plugin must record the
+	// last concrete built-in and re-apply it across that reset window, while
+	// treating a later, settled `system` switch as an explicit choice that clears it.
+	const h = buildSandbox();
+	const e = h.factory(makeRequire(makeRuntime().RT));
+	const themeHandlers = [];
+	let pref = 'system';
+	const setCalls = [];
+	const theme = {
+		register() { return () => {}; },
+		setTheme(id) { pref = id; setCalls.push(id); },
+		getTheme() { return { preference: pref, active: { id: pref === 'dark' ? 'dark' : 'light', colorScheme: 'dark', tokens: {} }, themes: [], revision: 1 }; },
+		overrideTokens() { return () => {}; }
+	};
+	const ctx = {
+		theme,
+		slots: { inject(n, f) { if (typeof f === 'function') f(); }, register() { return {}; } },
+		locale: { register() {}, bind() { return (k) => k; } },
+		on(ev, fn) { if (ev === 'theme/change') themeHandlers.push(fn); return () => {}; },
+		effect(t) { const d = t(); if (typeof d !== 'function') return; }
+	};
+	// Drive a built-in `dark` selection and record setTheme calls.
+	const emit = (p) => { pref = p; for (const fn of themeHandlers) fn({ preference: p, active: { id: 'dark', colorScheme: 'dark', tokens: {} }, revision: 2 }); };
+	const tick = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+	const darkCalls = () => setCalls.filter((id) => id === 'dark').length;
+
+	assert.doesNotThrow(() => e.apply(ctx));
+	// User picks a concrete built-in preference: dark (Appearance row calls
+	// setTheme('dark'), which fires theme/change — the plugin records it).
+	theme.setTheme('dark');
+	emit('dark');
+	assert.ok(darkCalls() >= 1, 'user setting dark invokes setTheme(dark)');
+	assert.equal(h.localStorage.getItem('dsh-dream-skin:builtin-last'), 'dark', 'dark choice recorded for later restore');
+
+	// Agent-preset change → connection reset → scope re-adoption → theme resets to
+	// system. Simulate a client remount: a FRESH plugin with the same localStorage
+	// (now holding builtin-last=dark) and the host re-adopting `system` right after
+	// mount, while the boot/reset window is still open (< BUILTIN_SETTLE_MS).
+	const h2 = buildSandbox({ seed: { 'dsh-dream-skin:builtin-last': 'dark' } });
+	const e2 = h2.factory(makeRequire(makeRuntime().RT));
+	const theme2Handlers = [];
+	let pref2 = 'system';
+	const setCalls2 = [];
+	const theme2 = {
+		register() { return () => {}; },
+		setTheme(id) { pref2 = id; setCalls2.push(id); },
+		getTheme() { return { preference: pref2, active: { id: 'dark', colorScheme: 'dark', tokens: {} }, themes: [], revision: 1 }; },
+		overrideTokens() { return () => {}; }
+	};
+	const ctx2 = {
+		theme: theme2,
+		slots: { inject(n, f) { if (typeof f === 'function') f(); }, register() { return {}; } },
+		locale: { register() {}, bind() { return (k) => k; } },
+		on(ev, fn) { if (ev === 'theme/change') theme2Handlers.push(fn); return () => {}; },
+		effect(t) { const d = t(); if (typeof d !== 'function') return; }
+	};
+	const emit2 = (p) => { pref2 = p; for (const fn of theme2Handlers) fn({ preference: p, active: { id: 'dark', colorScheme: 'dark', tokens: {} }, revision: 2 }); };
+	const darkCalls2 = () => setCalls2.filter((id) => id === 'dark').length;
+	assert.doesNotThrow(() => e2.apply(ctx2));
+	// The boot/reset window is open right after apply() (settle timer not yet fired).
+	// The host re-adopts system (remote browser lost process-local dark).
+	emit2('system');
+	await tick(30); // < builtinSettled (2000ms) — still in the boot/reset window
+	assert.ok(darkCalls2() >= 1, 'saved dark re-applied after the agent-preset reset to system');
+});
+
 test('setSkin auto-attaches the skin diffused-glow gradient when no user wallpaper is set', () => {
 	// Premium material look: picking a built-in skin should attach that skin's
 	// recommended iOS diffused-glow gradient automatically — but ONLY when the


### PR DESCRIPTION
Follow-up to issue #11's reporter feedback: the bug also hits BUILT-IN preferences (深色 / 跟随系统), not just third-party skins.

Root cause: DSH persists ui-theme.preference to the host settings file only for LOOPBACK browsers; a remote browser keeps it process-local, so a client reload / connection-reset (e.g. switching the agent preset) resets a concrete dark/light choice back to system.

This PR mirrors the third-party skin restore for built-in prefs:
- record the last user-committed concrete built-in preference (dark/light) in the plugin's own 3-layer storage;
- restore it at boot when no third-party skin is active;
- re-apply it when a system fallback lands in the boot/reset window, while treating a later settled system switch as an explicit choice that clears the record.

New regression test covers the built-in dark case; all 28 tests pass.
