### PR TITLE
fix(#29): wallpaper wash uses target-skin tokens after switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 记录 `dsh-dream-skin` 的可观变更。格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)，版本遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [0.4.11] - 2026-08-21
+
+> **壁纸遮罩切换皮肤后的兜底色修复。** 从深色切回浅色皮肤时，壁纸遮罩不再误用 DSH 内置的白色兜底，刷新后也不会有差异。
+
+### 修复
+- **切换皮肤后壁纸遮罩使用内置兜底色（issue #29）**：`setSkin()` 里 `syncSkinWith(id)` 原先在 `ctx.theme.setTheme(id)` 之后**同步**调用 `applyWallpaper2`，但此刻主题快照的 `active` 尚未切换/就绪，`shadeTokens2` 里的 `resolveBase/sidebar` 找不到目标皮肤 token，就回退到 `BUILTIN_BASE[scheme]`——浅色主题的兜底是白色，于是写入 `rgba(255,255,255,.8)` 这类错误遮罩，且没有在 active 就绪后校正，一直保留到刷新才恢复。现将 `syncSkinWith` 改为只同步选中态、**不再立即 re-shade**；壁纸遮罩的正确着色委托给 `theme/change` 监听（`syncSkin`），此时 `snapshot.active` 已是对应目标皮肤，可用正确 token 着色。换渐变时由 `setWallpaperKind` 兜底 re-shade，无遗漏路径。**31/31 测试通过**，新增 `rose→midnight→rose` 回归测试断言遮罩用 rose token 而非白色兜底。
+
 ## [0.4.10] - 2026-08-21
 
 > **URL 壁纸安全加固。** 壁纸「图片链接」不再原样拼进 CSS：只放行 http/https/data:image 链接（javascript:/file:/data:text/html 等一律拒绝并提示），拼 CSS 时对引号和反斜杠转义，应用后对坏链做预载检查并提示；顺带清理三处低危项。

--- a/lib/client.js
+++ b/lib/client.js
@@ -3263,12 +3263,20 @@ window.__ModuleLoader__.load({
 			let skinRevision = 0;
 			const syncSkinWith = (id) => {
 				skinBound?.sync(id, ++skinRevision);
-				// A skin/scheme switch changes the base color; re-shade the wash.
-				if (wallpaperBackgroundCss() !== null) applyWallpaper2(ctx);
+				// Do NOT re-shade the wallpaper here (issue #29): right after
+				// ctx.theme.setTheme(id), the theme snapshot's `active` is not yet the
+				// target skin, so shadeTokens2 -> resolveBase/sidebar cannot find the
+				// target tokens and falls back to BUILTIN_BASE[scheme] (white for light),
+				// writing a wrong wash (e.g. rgba(255,255,255,.8)) that persists until
+				// refresh. The correct re-shade is deferred to the theme/change listener
+				// (syncSkin), whose snapshot.active is already the settled target skin.
+				// When this skin also swaps in a built-in glow gradient, setWallpaperKind
+				// re-applies the wallpaper right after, so nothing is left stale.
 			};
 			const syncSkin = (snapshot) => {
 				skinBound?.sync(snapshot.preference, ++skinRevision);
-				// A skin/scheme switch changes the base color; re-shade the wash.
+				// snapshot.active is the settled target skin here — safe to re-shade the
+				// wallpaper wash with the target skin's tokens.
 				if (wallpaperBackgroundCss() !== null) applyWallpaper2(ctx);
 			};
 			ctx.on("theme/change", syncSkin);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-dream-skin",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "DeepSeek Harness 换肤插件（Dream Skin for DSH）：8 套 iOS / Linear 式清透冷调的高质感主题 + 弥散光壁纸 + 每皮肤智能背景 + 强调色 + 主题包分享，把换肤做成材质与配色克制的高级感工艺，而非贴图 — in the spirit of Codex Dream Skin, elevated.",
   "license": "MIT",
   "type": "module",

--- a/tests/client.smoke.test.cjs
+++ b/tests/client.smoke.test.cjs
@@ -762,6 +762,64 @@ test('setSkin swaps the built-in diffused-glow background when switching skins',
 	assert.equal(h.localStorage.getItem('dsh-dream-skin:wallpaper-follows-skin'), '1', 'still following after switch');
 });
 
+test('issue #29: wallpaper wash uses the target skin tokens, not BUILTIN_BASE fallback, after a skin round-trip', () => {
+	// Regression: switching rose -> midnight -> rose with a wallpaper wash must leave
+	// --dsw-alias-bg-base / --dsw-specific-sidebar-fill shaded with ROSE's tokens
+	// (rgba(247,240,243,.8)), not the light-theme BUILTIN_BASE white (rgba(255,255,255,.8)).
+	// The re-shade must run from the settled theme/change snapshot (target active), not
+	// from the synchronous setSkin path before the target is active.
+	const h = buildSandbox({
+		seed: {
+			'dsh-dream-skin:wallpaper-kind': 'gradient',
+			'dsh-dream-skin:wallpaper-gradient': 'linear-gradient(135deg, #222 0%, #444 100%)',
+			'dsh-dream-skin:wallpaper-opacity': '0.8',
+			'dsh-dream-skin:wallpaper-follows-skin': '0'
+		}
+	});
+	const e = h.factory(makeRequire(makeRuntime().RT));
+
+	// Minimal per-skin token tables so resolveBase/resolveSidebar can find them.
+	const SKINS2 = {
+		rose: { colorScheme: 'light', tokens: { '--dsw-alias-bg-base': '#f7f0f3', '--dsw-specific-sidebar-fill': '#f6e9ef' } },
+		midnight: { colorScheme: 'dark', tokens: { '--dsw-alias-bg-base': '#0b0b0e', '--dsw-specific-sidebar-fill': 'rgba(11,11,14,0.92)' } }
+	};
+	let cur = 'rose';
+	let changeHandler = null;
+	const wallpaperOverrides = [];
+	const activeFor = () => { const s = SKINS2[cur]; return { id: cur, colorScheme: s.colorScheme, tokens: s.tokens }; };
+	const theme = {
+		register() { return () => {}; },
+		setTheme(id) { cur = id; if (changeHandler) changeHandler({ preference: cur, active: activeFor(), themes: [], revision: 2 }); },
+		getTheme() { return { preference: cur, active: activeFor(), themes: [], revision: 1 }; },
+		overrideTokens(source, tokens) { if (source === 'dsh-dream-skin:wallpaper') wallpaperOverrides.push(tokens); return () => {}; }
+	};
+	const baseCtx = makeApplyContext(h, { captureActions: true });
+	const ctx = { ...baseCtx, theme };
+	// Ensure ctx.on('theme/change', ...) captures the handler this theme emits to.
+	const origOn = baseCtx.on;
+	ctx.on = (ev, fn) => { if (ev === 'theme/change') changeHandler = fn; return origOn(ev, fn); };
+	assert.doesNotThrow(() => e.apply(ctx));
+	const skinBags = h.actionBags['dream-skin'];
+	assert.ok(skinBags && typeof skinBags.setSkin === 'function', 'skin row setSkin captured');
+
+	// The user-kept gradient wallpaper means setSkin does NOT swap the wallpaper, so
+	// the wash re-shade must come from the settled theme/change snapshot (syncSkin).
+	const roseBase = () => wallpaperOverrides.length
+		? wallpaperOverrides[wallpaperOverrides.length - 1]['--dsw-alias-bg-base'].light
+		: null;
+
+	// rose -> midnight -> rose. After the final switch back to rose, the wash must use
+	// rose's (light) base #f7f0f3, NOT the built-in light fallback white.
+	skinBags.setSkin('midnight');
+	assert.ok(wallpaperOverrides.length > 0, 'wallpaper override produced after switching to midnight');
+	skinBags.setSkin('rose');
+	const lastLight = roseBase();
+	assert.ok(/rgba\(247,\s*240,\s*243,\s*0\.8\)/.test(lastLight),
+		'last wash light base must be ROSE token, not white fallback (got ' + lastLight + ')');
+	assert.ok(!/rgba\(255,\s*255,\s*255,\s*0\.8\)/.test(lastLight),
+		'light wash must not fall back to BUILTIN_BASE white');
+});
+
 test('saved skin survives a page refresh (fresh apply re-stores from localStorage)', () => {
 	// Regression for issue #8: selecting a skin must survive a plain page refresh.
 	// On refresh the SAME origin's localStorage is still present, but the plugin is


### PR DESCRIPTION
Release 0.4.11 — patch. Fixes issue #29: after switching skins (e.g. rose -> midnight -> rose) with a wallpaper wash, the base/sidebar wash incorrectly used the light-theme BUILTIN_BASE white until refresh. The synchronous re-shade in setSkin now defers to the settled theme/change snapshot, so the wash uses the target skin tokens. Adds a regression test; all 31 tests pass.
