### PR TITLE
fix: raise --dsw-alias-bg-layer-1 opacity so third-party plugin surfaces stay readable (issue #27)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -95,7 +95,7 @@ window.__ModuleLoader__.load({
 				tokens: {
 					// iOS/Linear 清透冷调重构：干净中性深灰底 + 白色低透明浮升玻璃面板 + 鲜亮靛蓝强调
 					"--dsw-alias-bg-base": "#101014",
-					"--dsw-alias-bg-layer-1": "rgba(255, 255, 255, 0.045)",
+					"--dsw-alias-bg-layer-1": "rgba(255, 255, 255, 0.65)",
 					"--dsw-alias-bg-layer-2": "rgba(26, 30, 42, 0.85)",
 					"--dsw-alias-bg-layer-3": "#1a1d27",
 					"--dsw-alias-bg-module-platform": "#151821",
@@ -135,7 +135,7 @@ window.__ModuleLoader__.load({
 				tokens: {
 					// iOS/Linear 清透冷调重构：青绿→天蓝低温系
 					"--dsw-alias-bg-base": "#0e1316",
-					"--dsw-alias-bg-layer-1": "rgba(255, 255, 255, 0.04)",
+					"--dsw-alias-bg-layer-1": "rgba(255, 255, 255, 0.65)",
 					"--dsw-alias-bg-layer-2": "rgba(22, 32, 34, 0.85)",
 					"--dsw-alias-bg-layer-3": "#182128",
 					"--dsw-alias-bg-module-platform": "#131c20",
@@ -175,7 +175,7 @@ window.__ModuleLoader__.load({
 				tokens: {
 					// iOS/Linear 清透冷调重构：紫青低温系
 					"--dsw-alias-bg-base": "#12101a",
-					"--dsw-alias-bg-layer-1": "rgba(255, 255, 255, 0.04)",
+					"--dsw-alias-bg-layer-1": "rgba(255, 255, 255, 0.65)",
 					"--dsw-alias-bg-layer-2": "rgba(30, 27, 44, 0.85)",
 					"--dsw-alias-bg-layer-3": "#1c1a28",
 					"--dsw-alias-bg-module-platform": "#171523",
@@ -215,7 +215,7 @@ window.__ModuleLoader__.load({
 				tokens: {
 					// iOS/Linear 清透冷调重构：暖橙但干净克制
 					"--dsw-alias-bg-base": "#16110d",
-					"--dsw-alias-bg-layer-1": "rgba(255, 255, 255, 0.04)",
+					"--dsw-alias-bg-layer-1": "rgba(255, 255, 255, 0.65)",
 					"--dsw-alias-bg-layer-2": "rgba(36, 28, 20, 0.85)",
 					"--dsw-alias-bg-layer-3": "#231b15",
 					"--dsw-alias-bg-module-platform": "#1b1712",
@@ -255,7 +255,7 @@ window.__ModuleLoader__.load({
 				tokens: {
 					// iOS/Linear 清透冷调重构：中性纯黑（保留 OLED 但清透）
 					"--dsw-alias-bg-base": "#0b0b0e",
-					"--dsw-alias-bg-layer-1": "rgba(255, 255, 255, 0.04)",
+					"--dsw-alias-bg-layer-1": "rgba(255, 255, 255, 0.65)",
 					"--dsw-alias-bg-layer-2": "rgba(22, 22, 28, 0.85)",
 					"--dsw-alias-bg-layer-3": "#181820",
 					"--dsw-alias-bg-module-platform": "#11111a",
@@ -335,7 +335,7 @@ window.__ModuleLoader__.load({
 				tokens: {
 					// 液态玻璃：真正的清透半透明白 + blur，冷蓝光晕透出，面板浮于其上
 					"--dsw-alias-bg-base": "#e9eef6",
-					"--dsw-alias-bg-layer-1": "rgba(255, 255, 255, 0.5)",
+					"--dsw-alias-bg-layer-1": "rgba(255, 255, 255, 0.65)",
 					"--dsw-alias-bg-layer-2": "rgba(255, 255, 255, 0.6)",
 					"--dsw-alias-bg-layer-3": "rgba(255, 255, 255, 0.68)",
 					"--dsw-alias-bg-module-platform": "rgba(243, 247, 252, 0.9)",


### PR DESCRIPTION
## 关联 issue
Fixes #27（半透明/毛玻璃主题下 dshmarket 界面文字叠在一起）

## 问题根因
- 深色玻璃皮肤把通用语义 token `--dsw-alias-bg-layer-1` 覆盖为 `rgba(255,255,255,0.04~0.045)`（仅 4% 不透明）
- `--dsw-alias-*` 是 DSH 提供给**所有 UI（含第三方插件）**的通用 token，第三方插件（如 dshmarket）的卡片背景直接消费它（`var(--dsw-alias-bg-layer-1)`）
- 结果：插件界面背景近乎全透明，背后内容透出 → 文字视觉重叠
- 为什么调「弹窗不透明度」无效：滑块只覆盖 `--dsw-alias-bg-overlay` / `--dsw-specific-menu` 两个 token，不涉及 `layer-*`

## 改动
- abyss / aurora / nebula / ember / midnight / mist 的 `--dsw-alias-bg-layer-1` → `rgba(255,255,255,0.65)`（保证第三方插件表面可读，同时保留玻璃层次感）
- `layer-2`（0.85）不动；浅色皮肤（ivory / rose，不透明）不动

## 验证
- `node --test tests/*.test.cjs`：30/30 通过（含 liquid-glass material 注入、modal-opacity token 覆盖测试）

## 说明（请维护者判断）
- 本 PR 由 DSH agent 辅助分析提出（PensiveFei 授权）：根因基于本地 dshmarket 源码与皮肤 token 定义逐行对照确认
- `0.65` 为建议值，可按实际视觉效果再调
- 后续设计建议：玻璃效果尽量走 `--dsw-specific-*` 专属 token（皮肤已有 specific-input-major / bubble / sidebar-fill 等），避免覆盖通用 `--dsw-alias-*` 层 token 波及第三方插件界面
