### PR TITLE
fix: prevent wallpaper wash feedback when switching skins

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2623,7 +2623,7 @@ window.__ModuleLoader__.load({
 		let _applyingWallpaper = false;
 
 		/** Re-render the wallpaper backdrop from the current config. */
-		function applyWallpaper2(ctx) {
+		function applyWallpaper2(ctx, snapshot = null) {
 			// Re-entrancy guard: overrideTokens() below emits `theme/change`, which our
 			// syncSkin listener would answer by calling applyWallpaper2 again — that
 			// recursion would overflow the stack. Applying while already applying is a
@@ -2648,27 +2648,31 @@ window.__ModuleLoader__.load({
 				// Auto-dim lowers the wash opacity when enabled.
 				const baseFill = readWallpaperOpacity();
 				const wash = readWallpaperAutodim() ? Math.min(baseFill, 0.45) : baseFill;
-				shadeTokens2(ctx, wash);
+				shadeTokens2(ctx, wash, snapshot);
 			} finally {
 				_applyingWallpaper = false;
 			}
 		}
 
 		/** Apply the wallpaper's token override layer with a configurable canvas wash. */
-		function shadeTokens2(ctx, canvasAlpha) {
-			const snapshot = ctx.theme.getTheme();
+		function shadeTokens2(ctx, canvasAlpha, snapshot = null) {
+			const current = snapshot || ctx.theme.getTheme();
+			// ThemeRuntime composes token override layers into snapshot.active. Reading
+			// the active value here would feed our previous wallpaper wash back into the
+			// next wash and hide the newly selected skin's raw base/sidebar colors.
+			const active = current.themes?.find((theme) => theme.id === current.active.id) || current.active;
 			// When "link sidebar to main canvas" is on (default), the sidebar wash
 			// uses the same alpha as the main canvas so the two halves don't look
 			// split; when off, it uses the separately configured sidebar opacity.
 			const sidebarAlpha = readSidebarLink() ? canvasAlpha : readSidebarOpacity();
 			const overrides = {
 				"--dsw-alias-bg-base": {
-					light: toRgba(resolveBase("light", snapshot.active), canvasAlpha),
-					dark: toRgba(resolveBase("dark", snapshot.active), canvasAlpha)
+					light: toRgba(resolveBase("light", active), canvasAlpha),
+					dark: toRgba(resolveBase("dark", active), canvasAlpha)
 				},
 				"--dsw-specific-sidebar-fill": {
-					light: toRgba(resolveSidebar("light", snapshot.active), sidebarAlpha),
-					dark: toRgba(resolveSidebar("dark", snapshot.active), sidebarAlpha)
+					light: toRgba(resolveSidebar("light", active), sidebarAlpha),
+					dark: toRgba(resolveSidebar("dark", active), sidebarAlpha)
 				}
 			};
 			wallpaperOverrideDispose?.();
@@ -3276,8 +3280,9 @@ window.__ModuleLoader__.load({
 			const syncSkin = (snapshot) => {
 				skinBound?.sync(snapshot.preference, ++skinRevision);
 				// snapshot.active is the settled target skin here — safe to re-shade the
-				// wallpaper wash with the target skin's tokens.
-				if (wallpaperBackgroundCss() !== null) applyWallpaper2(ctx);
+				// wallpaper wash with the target skin's raw tokens. Pass the full snapshot
+				// so shadeTokens2 can ignore its own composed override layer.
+				if (wallpaperBackgroundCss() !== null) applyWallpaper2(ctx, snapshot);
 			};
 			ctx.on("theme/change", syncSkin);
 			// Keep the Accent row's base color (the active theme's brand color) in

--- a/tests/client.smoke.test.cjs
+++ b/tests/client.smoke.test.cjs
@@ -837,6 +837,71 @@ test('issue #29: wallpaper wash uses the target skin tokens, not BUILTIN_BASE fa
 		'light wash must not fall back to BUILTIN_BASE white');
 });
 
+test('issue #29: skin-following gradient shades from raw theme tokens, not its own composed override', () => {
+	// Real ThemeRuntime folds override layers into snapshot.active. A wallpaper
+	// wash must resolve the registered raw theme from snapshot.themes; otherwise
+	// its previous white/default wash feeds back into the next skin selection.
+	const h = buildSandbox();
+	const e = h.factory(makeRequire(makeRuntime().RT));
+	let themes = [
+		{ id: 'light', colorScheme: 'light', tokens: { '--dsw-alias-bg-base': '#fff', '--dsw-specific-sidebar-fill': '#fff' } },
+		{ id: 'dark', colorScheme: 'dark', tokens: { '--dsw-alias-bg-base': '#151517', '--dsw-specific-sidebar-fill': '#151517' } }
+	];
+	let preference = 'system';
+	let revision = 0;
+	const changeHandlers = [];
+	const overrides = new Map();
+	const snapshot = () => {
+		const activeId = preference === 'system' ? 'light' : preference;
+		const raw = themes.find((theme) => theme.id === activeId);
+		const tokens = { ...raw.tokens };
+		for (const layer of overrides.values()) {
+			for (const [name, modes] of Object.entries(layer.tokens)) tokens[name] = modes[raw.colorScheme];
+		}
+		return { preference, active: { ...raw, tokens }, themes: [...themes], revision };
+	};
+	const publish = () => {
+		revision += 1;
+		const value = snapshot();
+		for (const handler of changeHandlers) handler(value);
+	};
+	const theme = {
+		register(definition) {
+			themes = [...themes, definition];
+			publish();
+			return () => {};
+		},
+		setTheme(id) { preference = id; publish(); },
+		getTheme() { return snapshot(); },
+		overrideTokens(source, tokens) {
+			const layer = { tokens };
+			overrides.set(source, layer);
+			publish();
+			return () => {
+				if (overrides.get(source) !== layer) return;
+				overrides.delete(source);
+				publish();
+			};
+		}
+	};
+	const baseCtx = makeApplyContext(h, { captureActions: true });
+	const ctx = { ...baseCtx, theme };
+	ctx.on = (ev, fn) => { if (ev === 'theme/change') changeHandlers.push(fn); return () => {}; };
+	assert.doesNotThrow(() => e.apply(ctx));
+	const skinBags = h.actionBags['dream-skin'];
+
+	// First selection from the default light theme must already use rose, not white.
+	skinBags.setSkin('rose');
+	let wash = overrides.get('dsh-dream-skin:wallpaper').tokens;
+	assert.match(wash['--dsw-alias-bg-base'].light, /rgba\(247,\s*240,\s*243,\s*0\.8\)/);
+
+	// The round-trip must not feed either prior wash back into the final rose wash.
+	skinBags.setSkin('midnight');
+	skinBags.setSkin('rose');
+	wash = overrides.get('dsh-dream-skin:wallpaper').tokens;
+	assert.match(wash['--dsw-alias-bg-base'].light, /rgba\(247,\s*240,\s*243,\s*0\.8\)/);
+});
+
 test('saved skin survives a page refresh (fresh apply re-stores from localStorage)', () => {
 	// Regression for issue #8: selecting a skin must survive a plain page refresh.
 	// On refresh the SAME origin's localStorage is still present, but the plugin is


### PR DESCRIPTION
## 修复说明 / Summary

这是对已关闭 Issue #29 的后续修复。

本 PR 修复开启“壁纸跟随皮肤”后，壁纸覆盖色可能被上一个皮肤污染的问题，包括首次选择 Material 粉，以及在深色和浅色皮肤之间往返切换的场景。

This is a follow-up fix for the closed issue #29.

It fixes wallpaper wash colors being contaminated by the previously active skin when “wallpaper follows skin” is enabled, including the first Material Rose selection and repeated switching between light and dark skins.

## 与已关闭 Issue #29 的关系 / Relation to closed issue #29

#29 已在 v0.4.11 中标记为已解决。原修复解决了主题切换时使用固定 `BUILTIN_BASE` 颜色的问题，修复方向是正确的。

但报告者更新到包含该修复的版本后重新验证，发现以下真实操作路径仍然可以复现问题：

- 第一次从默认主题切换到 Material 粉时，壁纸颜色可能仍接近默认白色；
- 从午夜黑等深色皮肤切回 Material 粉时，可能保留上一个皮肤的颜色；
- 同一个皮肤经过来回切换后，显示效果可能与第一次选择时不同。

进一步检查发现，遗漏的原因不是原 Issue 描述错误，而是原回归测试中的 ThemeRuntime 模拟与实际运行时存在一个关键差异：

- 测试模拟中的 `snapshot.active.tokens` 是原始主题 tokens；
- 实际 ThemeRuntime 中的 `snapshot.active.tokens` 已经合并了所有 token override，其中包括 `dsh-dream-skin` 自己写入的壁纸覆盖层。

因此，v0.4.11 的实现虽然已经改为读取目标主题，但仍可能从 `snapshot.active.tokens` 读回插件上一次写入的壁纸颜色，形成自反馈。这解释了为什么原回归测试能够通过、Issue 已关闭，但问题在真实应用中仍然可以复现。

本 PR 不撤销或替换 v0.4.11 的修复，而是在其基础上补齐真实 ThemeRuntime 的 token 合成语义。

Issue #29 was marked as resolved in v0.4.11. That fix correctly addressed the use of static `BUILTIN_BASE` colors during theme changes.

After updating to the version containing that fix, however, the reporter verified that the issue remained reproducible on the first Default → Material Rose selection and after switching from a dark skin back to Material Rose.

The missing case comes from a key difference between the previous test mock and the real ThemeRuntime:

- The test mock exposed raw theme tokens through `snapshot.active.tokens`.
- The real ThemeRuntime composes token override layers into `snapshot.active.tokens`, including the wallpaper override written by `dsh-dream-skin` itself.

As a result, the v0.4.11 implementation could read its previous wallpaper wash as the input for the next wash calculation. This explains why the previous regression test passed while the behavior remained reproducible in the real application.

This PR preserves the v0.4.11 fix and completes it by handling the actual ThemeRuntime token composition behavior.

## 根本原因 / Root cause

原实现使用 `snapshot.active.tokens` 计算壁纸颜色。真实 ThemeRuntime 会先把注册主题与所有 override layer 合成，然后才生成 `snapshot.active`。

这会形成以下反馈循环：

```text
上一次壁纸覆盖色
→ ThemeRuntime 合并进 snapshot.active.tokens
→ 插件使用 active.tokens 计算下一次壁纸颜色
→ 新覆盖色再次写入 ThemeRuntime
```

The previous implementation calculated the wallpaper wash from `snapshot.active.tokens`. Because the real ThemeRuntime composes override layers into `snapshot.active`, the plugin could consume its own previous output when calculating the next wash.

## 修复方式 / Fix

现在根据 `snapshot.active.id` 从 `snapshot.themes` 中查找当前皮肤对应的原始注册主题，并使用该主题的原始 tokens 计算主背景和侧边栏覆盖色。

壁纸渲染路径现在接收完整的 theme snapshot，从而明确区分：

- `snapshot.active`：已经合并 override 的运行时结果；
- `snapshot.themes`：注册时保存的原始皮肤定义。

示意逻辑：

```js
const current = snapshot || ctx.theme.getTheme();
const active =
  current.themes?.find((theme) => theme.id === current.active.id)
  || current.active;
```

只有无法从 `snapshot.themes` 找到对应主题时，才回退使用 `snapshot.active`，以保留兼容性。

The fix resolves the raw registered theme from `snapshot.themes` using `snapshot.active.id`, then calculates the canvas and sidebar wash from those raw tokens. It falls back to `snapshot.active` only when the matching registered theme cannot be found.

## 修改范围 / Scope

本 PR 仅修改：

- 壁纸覆盖色的主题 token 解析逻辑；
- 皮肤切换后重新计算壁纸颜色时的 snapshot 传递；
- 针对真实 ThemeRuntime override 合成行为的回归测试。

不修改皮肤注册数据、皮肤持久化、壁纸配置格式、ThemeRuntime 或其他插件代码。

This PR only changes theme token resolution for the wallpaper wash, snapshot forwarding after a skin change, and regression coverage for real ThemeRuntime override composition.

## 回归测试 / Regression coverage

新增测试模拟真实 ThemeRuntime 的关键行为：保存原始主题注册表，把 override layer 合并进 `snapshot.active.tokens`，并在 override 更新后发布新的 `theme/change` snapshot。

覆盖：

1. 默认主题 → Material 粉；
2. Material 粉 → 午夜黑 → Material 粉；
3. 确认切回后不会残留默认白色或深色皮肤的覆盖色。

Material 粉预期背景值：

```text
rgba(247, 240, 243, 0.8)
```

The new ThemeRuntime-style regression test covers the first Default → Material Rose selection and a Material Rose → Midnight → Material Rose round trip, including composed override layers in `snapshot.active.tokens`.

## 验证结果 / Verification

自动化检查：

- `npm test`：32/32 通过；
- `git diff --check`：通过；
- 新增回归测试在真实 override 合成模型下通过。

独立开发环境中的真实交互验证：

1. 以从未选择过皮肤的默认状态启动；
2. 第一次选择 Material 粉，立即显示正确的粉色背景；
3. 切换到午夜黑，正确显示深色背景；
4. 切回 Material 粉，恢复与首次选择一致的粉色；
5. 重复切换后，颜色仍保持稳定。

实际验证值：

```text
Default:             rgb(255, 255, 255)
First Material Rose: rgba(247, 240, 243, 0.8)
Midnight:            rgba(11, 11, 14, 0.8)
Material Rose again: rgba(247, 240, 243, 0.8)
```

在创建本 PR 前，问题报告者已在独立开发版本中实际确认修复有效。

Automated verification:

- `npm test`: 32/32 passed;
- `git diff --check`: passed;
- the regression test passes with ThemeRuntime-style override composition.

The fix was also verified in an isolated live development build. The reporter confirmed that the first selection and repeated light/dark switching now remain stable before this PR was opened.

## 兼容性与风险 / Compatibility and risk

该修改不会改变现有配置或持久化数据，只改变壁纸颜色计算时读取 token 的来源。如果运行时无法提供 `snapshot.themes`，实现仍会回退到 `snapshot.active`。

This change does not modify existing settings or persisted data. If `snapshot.themes` is unavailable or does not contain the active theme, the implementation falls back to `snapshot.active`.
