### PR TITLE
fix(client): drop backdrop-filter on composer card to unfix Tooltip anchoring

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1125,12 +1125,19 @@ window.__ModuleLoader__.load({
 		 * `--dsw-specific-input-major`) combined with `backdrop-filter: blur()`
 		 * so the diffused-glow wallpaper frosts through. Two safety rules, learned
 		 * from the earlier regression:
-		 *   1. We only target LEAF cards (composer `.uV2eYG_card`, inline warning
-		 *      `.bqrRRG_card`, todo popover `.lXshSW_root`, dock `.lXshSW_root`/panel)
-		 *      — none of these are ancestors of a `position:fixed` dialog, so
-		 *      adding backdrop-filter here cannot trap a fixed modal (the earlier
-		 *      bug was blurring LARGE columns that contained the fixed settings
-		 *      modal).
+		 *   1. We only target LEAF cards that do NOT host a `position:fixed`
+		 *      descendant. `backdrop-filter` (like `filter`/`transform`) turns
+		 *      the element into a containing block, so a fixed-positioned child
+		 *      is laid out relative to the card instead of the viewport. The
+		 *      composer card (`.uV2eYG_card`) deliberately carries the stop /
+		 *      send button Tooltips — fixed popovers — and blurring it made
+		 *      them anchor to the card and spill to the bottom-right corner,
+		 *      shoving the composer out of layout. So the material blur applies
+		 *      to the inline-warning card (`.bqrRRG_card`) and the todo
+		 *      popover/dock (`.lXshSW_root`, `._7yHdaG_panel`) but NOT to the
+		 *      composer card; the composer keeps its translucent token fill.
+		 *      (The earlier bug was blurring LARGE columns that contained the
+		 *      fixed settings modal.)
 		 *   2. `@supports` guards browsers without backdrop-filter; if a hashed
 		 *      class name changes in a future DSH the selectors no-op (blur just
 		 *      stops) without ever breaking layout.
@@ -1142,7 +1149,7 @@ window.__ModuleLoader__.load({
 			if (materialStyleEl !== null && document.head.contains(materialStyleEl)) return materialStyleEl;
 			const parts = [
 				"@supports ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {",
-				"  .uV2eYG_card, .bqrRRG_card {",
+				"  .bqrRRG_card {",
 				"    -webkit-backdrop-filter: blur(24px) saturate(150%);",
 				"    backdrop-filter: blur(24px) saturate(150%);",
 				"  }",

--- a/tests/client.smoke.test.cjs
+++ b/tests/client.smoke.test.cjs
@@ -1090,8 +1090,8 @@ test('modal-opacity row registers, persists, applies the CSS fill, and drives po
 
 test('liquid-glass material CSS is injected on leaf cards only (no fixed-modal ancestor)', () => {
 	// Regression guard for the settings-modal-trapping bug: the premium material
-	// injector must add backdrop-filter only to LEAF cards (composer, warning,
-	// popover) and NEVER to large columns/sidebar that could be ancestors of a
+	// injector must add backdrop-filter only to LEAF cards (warning, popover)
+	// and NEVER to large columns/sidebar that could be ancestors of a
 	// position:fixed modal. apply() must not throw, and the injected stylesheet
 	// must contain the safe leaf selectors and not the unsafe container one.
 	let appended = null;
@@ -1114,8 +1114,17 @@ test('liquid-glass material CSS is injected on leaf cards only (no fixed-modal a
 
 	assert.ok(appended && appended.textContent, 'a material <style> node was appended');
 	const css = appended.textContent;
-	assert.ok(css.includes('.uV2eYG_card'), 'composer card is a (safe) blur target');
 	assert.ok(css.includes('backdrop-filter'), 'uses backdrop-filter');
+	// The inline-warning card keeps the material blur — it hosts no fixed
+	// popover, so backdrop-filter cannot trap anything there.
+	assert.ok(css.includes('.bqrRRG_card'), 'inline-warning card is a (safe) blur target');
+	// The composer card must NOT be a blur target: it hosts the fixed-positioned
+	// stop/send button Tooltips. backdrop-filter (like filter/transform) turns an
+	// element into a containing block, so those tooltips anchor to the card
+	// instead of the viewport — they spill to the bottom-right corner and shove
+	// the composer out of layout. The composer keeps its translucent token fill;
+	// only the blur layer is dropped for it.
+	assert.ok(!/\.uV2eYG_card[^A-Za-z0-9_-]*\{[^}]*backdrop-filter/.test(css), 'composer card must NOT be a blur target (hosts fixed Tooltips)');
 	// The unsafe big containers MUST NOT be blurred (regression): those host the
 	// settings modal, and blurring them broke fixed positioning.
 	assert.ok(!/centerCol/.test(css), 'must NOT blur the main center column');


### PR DESCRIPTION
## 问题

悬停聊天输入框的**停止/发送按钮**时，按钮的 Tooltip（一个 `position:fixed` 弹出层，显示"停止生成 / Stop generating"）会渲染到**视口右下角**而不是锚定在按钮上，并且整个输入框被顶到页面顶部，聊天布局错乱。

## 根因

液态玻璃材质样式表向 `.uV2eYG_card`（输入框卡片）注入了 `backdrop-filter: blur(24px) saturate(150%)`。根据 CSS 规范，`backdrop-filter`（与 `filter` / `transform` 相同）会使该元素成为后代的**包含块（containing block）**。停止/发送按钮的 Tooltip 是渲染在输入框卡片内部的 `position:fixed` 弹出层，因此其定位锚点从视口变成了卡片——Tooltip 溢出到卡片右下角，并把输入框顶出布局。

原代码注释声称这些 leaf 卡片是安全的，因为"它们不是 fixed dialog 的祖先"，但 Tooltip 恰恰是位于输入框卡片内部的 fixed 弹出层，所以这个假设对输入框不成立。

## 修复

- 从 `backdrop-filter` 选择器中移除 `.uV2eYG_card`；输入框保留其半透明 token 填充（玻璃质感仍在），只是不再承载会困住 fixed 弹出层的 blur 层。
- 内联警告卡片（`.bqrRRG_card`）和 todo 弹层/坞站仍然使用材质 blur。
- 同步更新了 smoke 测试，断言输入框卡片**不得**成为 blur 目标（回归防护）。

## 验证

- `npm test`：33/33 通过（已更新材质 CSS leaf-card 断言）。
- 手动验证：插件启用状态下，运行中的会话里悬停停止按钮，Tooltip 不再错位，输入框也不再被顶起。