### PR TITLE
fix: reset sticky skin restore budget after successful recovery

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -3195,8 +3195,11 @@ window.__ModuleLoader__.load({
 					return;
 				}
 				if (current === "system" || current === "light" || current === "dark") {
-					ctx.theme.setTheme(savedSkin);
 					skinRestoreCount += 1;
+					// Count the attempt before setTheme(): ThemeRuntime publishes the
+					// successful saved-skin theme/change synchronously, and that event
+					// resets this consecutive-failure budget below.
+					ctx.theme.setTheme(savedSkin);
 				}
 			};
 			const scheduleSkinRestore = () => {
@@ -3277,7 +3280,16 @@ window.__ModuleLoader__.load({
 			ctx.on("theme/change", (snapshot) => {
 				const savedSkin = readSavedSkin();
 				const builtIn = snapshot.preference === "system" || snapshot.preference === "light" || snapshot.preference === "dark";
-				if (typeof savedSkin === "string" && savedSkin !== DEFAULT_SKIN && builtIn) scheduleSkinRestore();
+				if (typeof savedSkin === "string" && savedSkin !== DEFAULT_SKIN) {
+					if (snapshot.preference === savedSkin) {
+						// A successful restore ends the failure streak. Without this reset,
+						// ordinary locale reloads consume the lifetime cap and the ninth
+						// reload permanently falls back to Default (issue #36).
+						skinRestoreCount = 0;
+					} else if (builtIn) {
+						scheduleSkinRestore();
+					}
+				}
 				onBuiltinChange(snapshot);
 			});
 			settleBuiltin();

--- a/tests/client.smoke.test.cjs
+++ b/tests/client.smoke.test.cjs
@@ -560,6 +560,59 @@ test('saved third-party skin survives repeated delayed host adoption (sticky res
 	assert.equal(midnightCalls(), bootCount + 2, 'no restore after the user cleared the skin');
 });
 
+test('saved third-party skin survives more than eight successful locale reloads', async () => {
+	// Regression for issue #36: changing the locale makes DSH briefly re-adopt
+	// the built-in `system` preference. The restore guard is a consecutive-failure
+	// budget, so every successful return to the saved skin must reset it. Without
+	// that reset the ninth locale change permanently falls back to Default.
+	const h = buildSandbox({ seed: { 'dsh-dream-skin:skin': 'mist' } });
+	const e = h.factory(makeRequire(makeRuntime().RT));
+
+	const themeHandlers = [];
+	let pref = 'system';
+	const snapshot = () => ({
+		preference: pref,
+		active: { id: pref, colorScheme: 'light', tokens: {} },
+		themes: [],
+		revision: 1
+	});
+	const publish = () => {
+		for (const fn of themeHandlers) fn(snapshot());
+	};
+	const theme = {
+		register() { return () => {}; },
+		setTheme(id) {
+			if (pref === id) return;
+			pref = id;
+			publish();
+		},
+		getTheme() { return snapshot(); },
+		overrideTokens() { return () => {}; }
+	};
+	const ctx = {
+		theme,
+		slots: {
+			inject(n, f) { if (typeof f === 'function') f(); },
+			register() { return {}; }
+		},
+		locale: { register() {}, bind() { return (key) => key; } },
+		on(ev, fn) { if (ev === 'theme/change') themeHandlers.push(fn); return () => {}; },
+		effect(t) { t(); }
+	};
+	const tick = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+	e.apply(ctx);
+	await tick();
+	assert.equal(pref, 'mist', 'saved skin restored at boot');
+
+	for (let round = 1; round <= 12; round += 1) {
+		pref = 'system';
+		publish();
+		await tick();
+		assert.equal(pref, 'mist', `saved skin restored after locale reload ${round}`);
+	}
+});
+
 test('issue #11: saved skin survives an agent-preset change that re-adopts the host theme', async () => {
 	// Regression for issue #11: switching the agent preset in Settings → General
 	// makes DSH reload/re-adopt the host `ui-theme.preference` scope (which only


### PR DESCRIPTION
## 问题 / Problem

Fixes #36.

Issue #36 在 v0.4.14 中仍可复现，但并不是每次切换语言都会立即发生。

DSH 切换语言并重新加载界面时，会短暂把主题偏好恢复为内置的 `system`。`dsh-dream-skin` 会检测这一变化，并重新应用用户保存的第三方皮肤。问题在于：`skinRestoreCount` 统计的是插件进程生命周期内的累计恢复次数，而不是连续失败次数；每次成功恢复后，该计数都没有清零。

因此，前 8 次语言切换通常能正常恢复皮肤，看起来像是问题已经解决；第 9 次需要恢复时会触发 `MAX_SKIN_RESTORES` 限制，插件不再恢复保存的皮肤，界面便永久回落到 Default / System。

复现时，宿主持久化配置中的 `dsh-dream-skin:skin` 仍然是 `mist`，说明皮肤设置并未丢失。真正原因是运行时恢复保护额度被成功恢复逐次耗尽。

In v0.4.14, Issue #36 was still reproducible after enough locale switches. Locale reloads can temporarily make DSH adopt the built-in `system` theme. The plugin successfully restores the saved third-party skin, but `skinRestoreCount` accumulated those successful recoveries and was never reset. After eight successful recoveries, the ninth locale reload reached `MAX_SKIN_RESTORES` and permanently fell back to Default / System.

The durable host value remained `dsh-dream-skin:skin = mist`, confirming this was restore-guard exhaustion rather than lost persistence.

## 修复 / Fix

- 在调用同步触发 `theme/change` 的 `setTheme(savedSkin)` 之前记录本次恢复尝试。
- 当 `theme/change` 确认保存的第三方皮肤已经成功激活时，将恢复计数清零。
- 保留最多 8 次的保护机制，但让它只限制“连续失败”，不再限制插件整个生命周期内的成功恢复总次数。
- 增加回归测试，模拟同步 ThemeRuntime 事件以及 12 次语言重新加载。

- Count the restore attempt before calling synchronous `setTheme(savedSkin)`.
- Reset the restore budget when `theme/change` confirms that the saved skin is active.
- Keep the eight-attempt guard as consecutive-failure protection instead of a lifetime cap.
- Add a regression test covering synchronous ThemeRuntime events and 12 locale reloads.

## 验证 / Verification

- 修复前：新增回归测试稳定在第 9 次语言重新加载失败：`expected "mist", actual "system"`。
- 修复后：该回归测试通过。
- 完整测试：`npm test`，34/34 通过。
- 真实 Electron 开发版验证：
  - 使用 Liquid Glass / 液态玻璃皮肤；
  - 完成 6 轮中文 ↔ English 往返，共 12 次语言切换；
  - 再执行第 13 次切换到 English；
  - 皮肤、渐变壁纸、强调色、透明度和弹窗透明度均保持不变。

## 改动范围 / Scope

仅修改：

- `lib/client.js`
- `tests/client.smoke.test.cjs`

没有修改版本号，也没有引入新依赖。
