### PR TITLE
feat(client): settings nav 图标 -- Lucide palette 替换默认齿轮

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -3746,3 +3746,28 @@ window.__ModuleLoader__.load({
 		return module.exports;
 	}
 });
+
+/* [调色板/绘画板 (Lucide palette classic)] settings nav 齿轮替换 — 与 dsh-memory/dsh-achievements 同款图标库方案 */
+;(function () {
+  var MARKER = "data-dsh-dream-skin-nav"
+  var mask = "%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'24'%20height%3D'24'%20viewBox%3D'0%200%2024%2024'%20fill%3D'none'%20stroke%3D'black'%20stroke-width%3D'2'%20stroke-linecap%3D'round'%20stroke-linejoin%3D'round'%3E%3Ccircle%20cx%3D%2213.5%22%20cy%3D%226.5%22%20r%3D%221.05%22%2F%3E%3Ccircle%20cx%3D%2217.5%22%20cy%3D%2210.5%22%20r%3D%221.05%22%2F%3E%3Ccircle%20cx%3D%228.5%22%20cy%3D%227.5%22%20r%3D%221.05%22%2F%3E%3Ccircle%20cx%3D%226.5%22%20cy%3D%2212.5%22%20r%3D%221.05%22%2F%3E%3Cpath%20d%3D'M12%202C6.5%202%202%206.5%202%2012s4.5%2010%2010%2010c.926%200%201.648-.746%201.648-1.688%200-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64%201.64%200%200%201%201.668-1.668h1.996c3.051%200%205.555-2.503%205.555-5.554C21.965%206.012%2017.461%202%2012%202z'%2F%3E%3C%2Fsvg%3E"
+  var css = "[" + MARKER + "] > svg:first-child{display:none}" +
+    "[" + MARKER + "]::before{content:\"\";flex:none;width:16px;height:16px;background:currentColor;" +
+    "-webkit-mask:url(\"data:image/svg+xml," + mask + "\") center/contain no-repeat;" +
+    "mask:url(\"data:image/svg+xml," + mask + "\") center/contain no-repeat}"
+  var style = document.createElement("style")
+  style.id = "dsh-dream-skin-nav-icon"
+  style.textContent = css
+  document.head.append(style)
+  var sync = function () {
+    for (var b of document.querySelectorAll("[role=\"dialog\"] nav button")) {
+      var label = (b.textContent || "").trim()
+      var mm = label === "皮肤" || label === "Theme" || label.indexOf("Theme") !== -1
+      if (mm) b.setAttribute(MARKER, "")
+      else b.removeAttribute(MARKER)
+    }
+  }
+  sync()
+  var mo = new MutationObserver(sync)
+  mo.observe(document.body, { subtree: true, childList: true, characterData: true })
+})()


### PR DESCRIPTION
## 动机

DSH 0.1.x 的 settings.section 无 icon 契约——外部插件 section 在设置页导航一律显示默认齿轮，本插件的「Theme / 外观」行也如此，与主题/皮肤语义不符。

## 改动

复用社区同款模式（dsh-memory 大脑图标等同款）：

- MutationObserver 按当前本地化 label 标记设置弹窗 nav 行（data-dsh-dream-skin-nav），zh/en label 均匹配（Theme / 外观、皮肤）
- CSS mask 将图标替换为 Lucide palette（调色板/绘画板）——主题语义贴切
- 仅 lib/client.js（仓库交付形态为预编译 bundle，无 src 目录）；不动 host 部分

## 兼容性

- 无新增依赖（SVG 内联 data-uri）
- 弹窗未打开时无副作用；nav 行未匹配到时不改动任何 DOM
- 已在本机 DSH 0.1.1-rc.2 实测：图标替换生效、console 零错误