### PR TITLE
fix(client): point defineStore require at dsh-client-store for DSH master

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -23,7 +23,7 @@ window.__ModuleLoader__.load({
 		Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 		let react_jsx_runtime = require("react/jsx-runtime");
 		let _react = require("react");
-		let _runtime_client = require("@deepseek-ai/dsh-client-runtime/client");
+		let _runtime_client = require("@deepseek-ai/dsh-client-store");
 
 		//#region dsh-dream-skin: constants & presets
 		/** The settings row's locale namespace. */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-dream-skin",
-  "version": "8.28.0",
+  "version": "8.28.1",
   "description": "DeepSeek Harness 换肤插件（Dream Skin for DSH）：8 套 iOS / Linear 式清透冷调的高质感主题 + 弥散光壁纸 + 每皮肤智能背景 + 强调色 + 主题包分享，把换肤做成材质与配色克制的高级感工艺，而非贴图 — in the spirit of Codex Dream Skin, elevated.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

One-line fix for DeepSeek Harness **master** compatibility (see #41).

`lib/client.js` required `@deepseek-ai/dsh-client-runtime/client` which no longer exists on master. The bundle's only runtime use of that module is `defineStore` (6 call sites — the skin settings store + theme pack stores). Master's frozen module table (`PLATFORM_MODULES`) seeds `@deepseek-ai/dsh-client-store`, which exports the same `defineStore` contract, so the require target simply moves:

```diff
- let _runtime_client = require("@deepseek-ai/dsh-client-runtime/client");
+ let _runtime_client = require("@deepseek-ai/dsh-client-store");
```

Version bumped to **8.28.1**.

## Verification (live, DSH master + `dsh web`)

- Shell boots with **zero console errors** (previously: whole shell `Failed to load plugins`).
- Settings `Theme / 外观` panel fully renders: 8 skins (iOS 扁平 etc.), accent picker, wallpaper upload/opacity, recent wallpapers, URL/gradient wallpaper, dialog opacity, theme pack import/share.

## Notes

- The pbundle keeps `require("react")` / `require("react/jsx-runtime")` externals — both remain platform seeds on master.
- No `dsh.client` manifest changes needed: the package's `./client` export is picked up by `dsh-client-modules` like the shipped `ui-*` packages.
